### PR TITLE
Make browse_all a function

### DIFF
--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -118,7 +118,6 @@ class Home(Base):
             items = self.find_elements(*self._extensions_locator)
             return [Home.PromoShelvesAddons(self.page, el) for el in items]
 
-        @property
         def browse_all(self):
             self.find_element(*self._browse_all_locator).click()
             from pages.desktop.search import Search
@@ -143,7 +142,6 @@ class Home(Base):
             items = self.find_elements(*self._themes_locator)
             return [Home.PromoShelvesAddons(self.page, el) for el in items]
 
-        @property
         def browse_all(self):
             self.find_element(*self._browse_all_locator).click()
             from pages.desktop.search import Search

--- a/regions/desktop/shelves.py
+++ b/regions/desktop/shelves.py
@@ -38,7 +38,6 @@ class Shelves(Region):
         def card_header(self):
             return self.find_element(*self._promo_card_header_locator).text
 
-        @property
         def browse_all(self):
             self.find_element(*self._browse_all_locator).click()
             from pages.desktop.search import Search

--- a/test_extensions.py
+++ b/test_extensions.py
@@ -66,7 +66,7 @@ def test_recommended_extensions_shelf(base_url, selenium):
 @pytest.mark.nondestructive
 def test_browse_more_recommended_extensions(base_url, selenium):
     extensions = Extensions(selenium, base_url).open()
-    extensions.shelves.recommended_addons.browse_all
+    extensions.shelves.recommended_addons.browse_all()
     assert 'type=extension' in selenium.current_url
     search_results = Search(selenium, base_url)
     select = Select(search_results.filter_by_badging)
@@ -92,7 +92,7 @@ def test_top_rated_extensions(base_url, selenium):
 @pytest.mark.nondestructive
 def test_browse_more_top_rated_extensions(base_url, selenium):
     extensions = Extensions(selenium, base_url).open()
-    extensions.shelves.top_rated_addons.browse_all
+    extensions.shelves.top_rated_addons.browse_all()
     assert 'sort=rating&type=extension' in selenium.current_url
     search_results = Search(selenium, base_url)
     select = Select(search_results.filter_by_badging)
@@ -123,7 +123,7 @@ def test_trending_extensions(base_url, selenium):
 @pytest.mark.nondestructive
 def test_browse_more_trending_extensions(base_url, selenium):
     extensions = Extensions(selenium, base_url).open()
-    extensions.shelves.trending_addons.browse_all
+    extensions.shelves.trending_addons.browse_all()
     assert 'sort=hotness&type=extension' in selenium.current_url
     search_results = Search(selenium, base_url)
     select = Select(search_results.filter_by_badging)

--- a/test_home.py
+++ b/test_home.py
@@ -37,7 +37,7 @@ def test_logo_routes_to_home(base_url, selenium):
 @pytest.mark.nondestructive
 def test_browse_all_button_loads_correct_page(base_url, selenium):
     page = Home(selenium, base_url).open()
-    page.recommended_extensions.browse_all
+    page.recommended_extensions.browse_all()
     assert 'type=extension' in selenium.current_url
     search_page = Search(selenium, base_url)
     for result in search_page.result_list.extensions:


### PR DESCRIPTION
Fix #103 


While doing this I've realized that we have the `browse_all` function in two places: `pages/home.py` and `regions/shelves.py`.
I think the function should only exist in  `regions/shelves.py` because it's a shelf specific function.

I'll file a follow up issue to track the changes that need to be done to make this move.