### PR TITLE
Add tests for incompatible addons

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -9,6 +9,7 @@ class Detail(Base):
     _addon_name_locator = (By.CLASS_NAME, 'AddonTitle')
     _compatible_locator = (By.CSS_SELECTOR, '.AddonCompatibilityError')
     _install_button_locator = (By.CLASS_NAME, 'AMInstallButton-button')
+    _install_button_state_locator = (By.CSS_SELECTOR, '.AMInstallButton a')
 
     def wait_for_page_to_load(self):
         self.wait.until(
@@ -24,6 +25,10 @@ class Detail(Base):
     def is_compatible(self):
         return not self.is_element_displayed(*self._compatible_locator)
 
+    @property
+    def incompatibility_message(self):
+        return self.find_element(*self._compatible_locator).text
+
     def install(self):
         self.find_element(*self._install_button_locator).click()
 
@@ -34,5 +39,7 @@ class Detail(Base):
         return self.find_element(*self._install_button_locator).text
 
     @property
-    def button_enabled(self):
-        return self.find_element(*self._install_button_locator).is_enabled()
+    def button_state_disabled(self):
+        # checking that an inactive install button has a 'disabled' attribute
+        return self.find_element(*self._install_button_state_locator).\
+            get_attribute('disabled')

--- a/stage.json
+++ b/stage.json
@@ -1,4 +1,7 @@
 {
   "base_url": "https://addons.allizom.org",
-  "search_term": "Flagfox"
+  "search_term": "Flagfox",
+  "lower_firefox_version": "lower-firefox",
+  "higher_firefox_version": "wombarish-humminocon-elamster",
+  "incompatible_platform": "thursdayafternoon"
 }

--- a/test_addon_detail.py
+++ b/test_addon_detail.py
@@ -1,0 +1,33 @@
+import pytest
+
+from pages.desktop.details import Detail
+
+
+@pytest.mark.nondestructive
+def test_lower_firefox_incompatibility(selenium, base_url, variables):
+    extension = variables['lower_firefox_version']
+    selenium.get('{}/addon/{}'.format(base_url, extension))
+    addon = Detail(selenium, base_url)
+    assert 'This add-on is not compatible with your version of Firefox.' \
+           in addon.incompatibility_message
+    assert addon.button_state_disabled
+
+
+@pytest.mark.nondestructive
+def test_higher_firefox_incompatibility(selenium, base_url, variables):
+    extension = variables['higher_firefox_version']
+    selenium.get('{}/addon/{}'.format(base_url, extension))
+    addon = Detail(selenium, base_url)
+    assert 'This add-on requires a newer version of Firefox' \
+           in addon.incompatibility_message
+    assert addon.button_state_disabled
+
+
+@pytest.mark.nondestructive
+def test_platform_incompatibility(selenium, base_url, variables):
+    extension = variables['incompatible_platform']
+    selenium.get('{}/addon/{}'.format(base_url, extension))
+    addon = Detail(selenium, base_url)
+    assert 'This add-on is not available on your platform.' \
+           in addon.incompatibility_message
+    assert addon.button_state_disabled


### PR DESCRIPTION
With this PR I'm adding a new test module - `test_addon_detail.py` - which will contain tests specific for extensions and theme detail pages.
First, I'm adding some tests for add-on incompatibility messages. 