### PR TITLE
Update YouTube link in footer test

### DIFF
--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -149,7 +149,7 @@ def test_products_footer_links(base_url, selenium, count, links):
 
 @pytest.mark.parametrize(
     "count, links",
-    enumerate(["twitter.com", "facebook.com", "youtube.com/c/firefox", ]),
+    enumerate(["twitter.com", "facebook.com", "youtube.com/channel/", ]),
 )
 @pytest.mark.nondestructive
 def test_social_footer_links(base_url, selenium, count, links):


### PR DESCRIPTION
The link for the Firefox YouTube channel has been changed, so we needed to update our `test_social_footer_links` test.