### PR TITLE
AMO and DevHub homepage shared footer

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -242,7 +242,7 @@ class Footer(Region):
     _root_locator = (By.CSS_SELECTOR, '.Footer-wrapper')
     _footer_amo_links_locator = (By.CSS_SELECTOR, '.Footer-amo-links')
     _footer_browsers_links_locator = (By.CSS_SELECTOR, '.Footer-browsers-links')
-    _footer_products_links_locator = (By.CSS_SELECTOR, '.Footer-product-links')
+    _footer_products_links_locator = (By.CSS_SELECTOR, '.Footer-wrapper section:nth-child(4)')
     _footer_mozilla_link_locator = (By.CSS_SELECTOR, '.Footer-mozilla-link')
     _footer_social_locator = (By.CSS_SELECTOR, '.Footer-links-social')
     _footer_links_locator = (By.CSS_SELECTOR, '.Footer-links li a')

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pages.desktop.base import Base
 from pages.desktop.home import Home
 from pages.desktop.search import Search
 
@@ -80,14 +81,17 @@ def test_theme_categories_shelf(base_url, selenium, count, category):
     category_results.wait_for_contextcard_update(category)
 
 
-# Tests covering the homepage footer
+# Tests covering the homepage footer (AMO and DevHub)
+@pytest.mark.parametrize('page', ['', '/developers'])
 @pytest.mark.nondestructive
-def test_mozilla_footer_link(base_url, selenium):
-    page = Home(selenium, base_url).open()
+def test_mozilla_footer_link(base_url, selenium, page):
+    selenium.get(f'{base_url}{page}')
+    page = Base(selenium, base_url)
     page.footer.mozilla_link.click()
     assert "mozilla.org" in selenium.current_url
 
 
+@pytest.mark.parametrize('page', ['', '/developers'])
 @pytest.mark.parametrize(
     "count, links",
     enumerate(
@@ -105,12 +109,14 @@ def test_mozilla_footer_link(base_url, selenium):
     ),
 )
 @pytest.mark.nondestructive
-def test_addons_footer_links(base_url, selenium, count, links):
-    page = Home(selenium, base_url).open()
+def test_addons_footer_links(base_url, selenium, page, count, links):
+    selenium.get(f'{base_url}{page}')
+    page = Base(selenium, base_url)
     page.footer.addon_links[count].click()
     page.wait_for_current_url(links)
 
 
+@pytest.mark.parametrize('page', ['', '/developers'])
 @pytest.mark.parametrize(
     "count, links",
     enumerate(
@@ -123,8 +129,9 @@ def test_addons_footer_links(base_url, selenium, count, links):
     ),
 )
 @pytest.mark.nondestructive
-def test_browsers_footer_links(base_url, selenium, count, links):
-    page = Home(selenium, base_url).open()
+def test_browsers_footer_links(base_url, selenium, page, count, links):
+    selenium.get(f'{base_url}{page}')
+    page = Home(selenium, base_url)
     page.footer.browsers_links[count].click()
     page.wait_for_current_url(links)
 
@@ -147,24 +154,28 @@ def test_products_footer_links(base_url, selenium, count, links):
     page.wait_for_current_url(links)
 
 
+@pytest.mark.parametrize('page', ['', '/developers'])
 @pytest.mark.parametrize(
     "count, links",
     enumerate(["twitter.com", "facebook.com", "youtube.com/channel/", ]),
 )
 @pytest.mark.nondestructive
-def test_social_footer_links(base_url, selenium, count, links):
-    page = Home(selenium, base_url).open()
+def test_social_footer_links(base_url, selenium, page, count, links):
+    selenium.get(f'{base_url}{page}')
+    page = Base(selenium, base_url)
     page.footer.social_links[count].click()
     page.wait_for_current_url(links)
 
 
+@pytest.mark.parametrize('page', ['', '/developers'])
 @pytest.mark.parametrize(
     "count, links",
     enumerate(["privacy/websites/", "privacy/websites/", "legal/terms/mozilla", ]),
 )
 @pytest.mark.nondestructive
-def test_legal_footer_links(base_url, selenium, count, links):
-    page = Home(selenium, base_url).open()
+def test_legal_footer_links(base_url, selenium, page, count, links):
+    selenium.get(f'{base_url}{page}')
+    page = Base(selenium, base_url)
     page.footer.legal_links[count].click()
     page.wait_for_current_url(links)
 

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -82,7 +82,8 @@ def test_theme_categories_shelf(base_url, selenium, count, category):
 
 
 # Tests covering the homepage footer (AMO and DevHub)
-@pytest.mark.parametrize('page', ['', '/developers'])
+@pytest.mark.parametrize('page', ['', '/developers'],
+                         ids=['AMO footer', 'DevHub footer'])
 @pytest.mark.nondestructive
 def test_mozilla_footer_link(base_url, selenium, page):
     selenium.get(f'{base_url}{page}')
@@ -91,9 +92,10 @@ def test_mozilla_footer_link(base_url, selenium, page):
     assert "mozilla.org" in selenium.current_url
 
 
-@pytest.mark.parametrize('page', ['', '/developers'])
+@pytest.mark.parametrize('page', ['', '/developers'],
+                         ids=['AMO footer', 'DevHub footer'])
 @pytest.mark.parametrize(
-    "count, links",
+    "count, link",
     enumerate(
         [
             "about",
@@ -109,16 +111,17 @@ def test_mozilla_footer_link(base_url, selenium, page):
     ),
 )
 @pytest.mark.nondestructive
-def test_addons_footer_links(base_url, selenium, page, count, links):
+def test_addons_footer_links(base_url, selenium, page, count, link):
     selenium.get(f'{base_url}{page}')
     page = Base(selenium, base_url)
     page.footer.addon_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link)
 
 
-@pytest.mark.parametrize('page', ['', '/developers'])
+@pytest.mark.parametrize('page', ['', '/developers'],
+                         ids=['AMO footer', 'DevHub footer'])
 @pytest.mark.parametrize(
-    "count, links",
+    "count, link",
     enumerate(
         [
             "firefox/new",
@@ -129,15 +132,17 @@ def test_addons_footer_links(base_url, selenium, page, count, links):
     ),
 )
 @pytest.mark.nondestructive
-def test_browsers_footer_links(base_url, selenium, page, count, links):
+def test_browsers_footer_links(base_url, selenium, page, count, link):
     selenium.get(f'{base_url}{page}')
     page = Home(selenium, base_url)
     page.footer.browsers_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link)
 
 
+@pytest.mark.parametrize('page', ['', '/developers'],
+                         ids=['AMO footer', 'DevHub footer'])
 @pytest.mark.parametrize(
-    "count, links",
+    "count, link",
     enumerate(
         [
             "firefox/lockwise/",
@@ -148,36 +153,38 @@ def test_browsers_footer_links(base_url, selenium, page, count, links):
     ),
 )
 @pytest.mark.nondestructive
-def test_products_footer_links(base_url, selenium, count, links):
+def test_products_footer_links(base_url, selenium, page, count, link):
     page = Home(selenium, base_url).open()
     page.footer.products_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link)
 
 
-@pytest.mark.parametrize('page', ['', '/developers'])
+@pytest.mark.parametrize('page', ['', '/developers'],
+                         ids=['AMO footer', 'DevHub footer'])
 @pytest.mark.parametrize(
-    "count, links",
-    enumerate(["twitter.com", "facebook.com", "youtube.com/channel/", ]),
+    "count, link",
+    enumerate(["twitter.com", "facebook.com", "youtube.com", ]),
 )
 @pytest.mark.nondestructive
-def test_social_footer_links(base_url, selenium, page, count, links):
+def test_social_footer_links(base_url, selenium, page, count, link):
     selenium.get(f'{base_url}{page}')
     page = Base(selenium, base_url)
     page.footer.social_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link)
 
 
-@pytest.mark.parametrize('page', ['', '/developers'])
+@pytest.mark.parametrize('page', ['', '/developers'],
+                         ids=['AMO footer', 'DevHub footer'])
 @pytest.mark.parametrize(
-    "count, links",
+    "count, link",
     enumerate(["privacy/websites/", "privacy/websites/", "legal/terms/mozilla", ]),
 )
 @pytest.mark.nondestructive
-def test_legal_footer_links(base_url, selenium, page, count, links):
+def test_legal_footer_links(base_url, selenium, page, count, link):
     selenium.get(f'{base_url}{page}')
     page = Base(selenium, base_url)
     page.footer.legal_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link)
 
 
 @pytest.mark.nondestructive


### PR DESCRIPTION
I started working on adding tests for the Developer Hub - https://addons.allizom.org/developers/ - homepage as part of my Q1 project goal and I've noticed that its main footer  has  mostly the same locators as the AMO footer (except for the sections crossed out in the screenshot).

![image](https://user-images.githubusercontent.com/31961530/110954995-c8d62880-8351-11eb-8d66-989576091e9f.png)


Since we already have tests covering the main AMO footer in https://github.com/mozilla/addons-release-tests/blob/master/tests/test_home.py, I think we should try to use those tests for both pages, rather than adding new almost identical tests for DevHub.

I'm not sure if my approach is correct or if there is a better way to implement this, hence I'm making this a draft PR. 

