### PR TITLE
Fix theme and extension category tests

### DIFF
--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -34,7 +34,6 @@ def test_extensions_categories(base_url, selenium, count, category):
     category_results = Search(selenium, base_url)
     # checking that category search results are loaded and sorted by users
     category_results.wait_for_contextcard_update(category)
-    assert 'sort=recommended%2Cusers' in selenium.current_url
     select = Select(category_results.filter_by_sort)
     assert 'Most Users' in select.first_selected_option.text
 

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -34,7 +34,6 @@ def test_themes_categories(base_url, selenium, count, category):
     category_results = Search(selenium, base_url)
     # checking that search results within that category are sorted correctly
     category_results.wait_for_contextcard_update(category)
-    assert 'sort=recommended%2Cusers' in selenium.current_url
     select = Select(category_results.filter_by_sort)
     assert 'Most Users' in select.first_selected_option.text
 


### PR DESCRIPTION
There has been a change in the Themes and Extensions Category landing pages URLs, so I had to remove an assertion since it is no longer valid in the new context. 