### PR TITLE
Fix youtube footer link

### DIFF
--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -149,7 +149,7 @@ def test_products_footer_links(base_url, selenium, count, links):
 
 @pytest.mark.parametrize(
     "count, links",
-    enumerate(["twitter.com", "facebook.com", "youtube.com/channel/", ]),
+    enumerate(["twitter.com", "facebook.com", "youtube.com", ]),
 )
 @pytest.mark.nondestructive
 def test_social_footer_links(base_url, selenium, count, links):


### PR DESCRIPTION
The youtube link has changed a couple times in the past, so I'm renaming it to just  'youtube.com' to keep the data valid if any other changes occur. 