### PR TITLE
Fix log output in html report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 2
-          command: pytest --driver Firefox --variables stage.json --html=ui-test-release.html --self-contained-html
+          command: pytest --driver Firefox --variables stage.json
           no_output_timeout: 30m
       - store_artifacts:
           path: ui-test-release.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
-addopts = -vs --tb=long --showlocals --html=ui-test-release.html --self-contained-html
+addopts = -v --tb=long --showlocals --html=ui-test-release.html --self-contained-html
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
-addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html
+addopts = -vs --tb=long --showlocals --html=ui-test-release.html --self-contained-html
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true

--- a/tests/test_addon_detail.py
+++ b/tests/test_addon_detail.py
@@ -55,7 +55,8 @@ def test_extension_permissions(selenium, base_url, variables):
     extension = variables['detail_extension_slug']
     selenium.get('{}/addon/{}'.format(base_url, extension))
     addon = Detail(selenium, base_url)
-    assert 'Permissions' in addon.permissions.permissions_card_header
+    # assert 'Permissions' in addon.permissions.permissions_card_header
+    assert 'Purposely fail test' in addon.permissions.permissions_card_header
     permissions = addon.permissions.permissions_list
     # checks that each permission has a corresponding icon and description
     for permission in permissions:

--- a/tests/test_addon_detail.py
+++ b/tests/test_addon_detail.py
@@ -55,8 +55,7 @@ def test_extension_permissions(selenium, base_url, variables):
     extension = variables['detail_extension_slug']
     selenium.get('{}/addon/{}'.format(base_url, extension))
     addon = Detail(selenium, base_url)
-    # assert 'Permissions' in addon.permissions.permissions_card_header
-    assert 'Purposely fail test' in addon.permissions.permissions_card_header
+    assert 'Permissions' in addon.permissions.permissions_card_header
     permissions = addon.permissions.permissions_list
     # checks that each permission has a corresponding icon and description
     for permission in permissions:


### PR DESCRIPTION
Trying to fix log output in html reports by updating the report title in circleci config and setup config files. 

Tweaked the cli arguments from setup.cfg and now we're capturing log output in pytest-html reports:

 https://388-242947140-gh.circle-artifacts.com/0/ui-test-release.html
![image](https://user-images.githubusercontent.com/31961530/113264665-e442ac80-92db-11eb-8263-8d337da1d495.png)
