### PR TITLE
Add-on author link in detail page

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -23,6 +23,7 @@ class Detail(Base):
     _install_warning_button_locator = (By.CSS_SELECTOR, '.InstallWarning a')
 
     def wait_for_page_to_load(self):
+        """Waits for various page components to be loaded"""
         self.wait.until(
             expected.invisibility_of_element_located(
                 (By.CLASS_NAME, 'LoadingText')))

--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -16,7 +16,7 @@ class Detail(Base):
     _promoted_badge_label_locator = (By.CSS_SELECTOR, '.PromotedBadge-large .PromotedBadge-label')
     _experimental_badge_locator = (By.CLASS_NAME, 'Badge-experimental')
     _addon_icon_locator = (By.CLASS_NAME, 'Addon-icon-image')
-    _author_locator = (By.CSS_SELECTOR, '.AddonTitle-author a')
+    _addon_author_locator = (By.CSS_SELECTOR, '.AddonTitle-author a')
     _summary_locator = (By.CLASS_NAME, 'Addon-summary')
     _install_warning_locator = (By.CLASS_NAME, 'InstallWarning')
     _install_warning_text_locator = (By.CSS_SELECTOR, '.InstallWarning p')
@@ -82,7 +82,7 @@ class Detail(Base):
 
     @property
     def authors(self):
-        return self.find_element(*self._author_locator)
+        return self.find_element(*self._addon_author_locator)
 
     @property
     def summary(self):

--- a/pages/desktop/users.py
+++ b/pages/desktop/users.py
@@ -1,4 +1,5 @@
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
 
 from pages.desktop.base import Base
 
@@ -6,9 +7,11 @@ from pages.desktop.base import Base
 class User(Base):
     _display_name_locator = (By.CLASS_NAME, 'UserProfile-name')
 
-    def wait_for_user_to_load(self):
+    def wait_for_page_to_load(self):
+        """Waits for various page components to be loaded"""
         self.wait.until(
-            lambda _: self.is_element_displayed(*self._display_name_locator))
+            expected.invisibility_of_element_located(
+                (By.CLASS_NAME, 'LoadingText')))
         return self
 
     @property

--- a/pages/desktop/users.py
+++ b/pages/desktop/users.py
@@ -1,0 +1,16 @@
+from selenium.webdriver.common.by import By
+
+from pages.desktop.base import Base
+
+
+class User(Base):
+    _display_name_locator = (By.CLASS_NAME, 'UserProfile-name')
+
+    def wait_for_user_to_load(self):
+        self.wait.until(
+            lambda _: self.is_element_displayed(*self._display_name_locator))
+        return self
+
+    @property
+    def user_display_name(self):
+        return self.find_element(*self._display_name_locator).text

--- a/tests/test_addon_detail.py
+++ b/tests/test_addon_detail.py
@@ -25,11 +25,11 @@ def test_detail_author_links(selenium, base_url, variables):
     extension = variables['detail_extension_slug']
     selenium.get(f'{base_url}/addon/{extension}')
     # read the add-on author name and clicks on it
-    addon = Detail(selenium, base_url)
+    addon = Detail(selenium, base_url).wait_for_page_to_load()
     author = addon.authors.text
     addon.authors.click()
     # verify that the author profile page opens
-    user = User(selenium, base_url)
+    user = User(selenium, base_url).wait_for_page_to_load()
     assert author in user.user_display_name
 
 

--- a/tests/test_addon_detail.py
+++ b/tests/test_addon_detail.py
@@ -5,6 +5,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as expected
 
 from pages.desktop.details import Detail
+from pages.desktop.users import User
 
 
 @pytest.mark.nondestructive
@@ -17,6 +18,19 @@ def test_extension_meta_card(selenium, base_url, variables):
     assert addon.addon_icon.is_displayed()
     assert addon.authors.is_displayed()
     assert addon.summary.is_displayed()
+
+
+@pytest.mark.nondestructive
+def test_detail_author_links(selenium, base_url, variables):
+    extension = variables['detail_extension_slug']
+    selenium.get(f'{base_url}/addon/{extension}')
+    # read the add-on author name and clicks on it
+    addon = Detail(selenium, base_url)
+    author = addon.authors.text
+    addon.authors.click()
+    # verify that the author profile page opens
+    user = User(selenium, base_url)
+    assert author in user.user_display_name
 
 
 @pytest.mark.nondestructive


### PR DESCRIPTION
A test that clicks on the add-on author link in the detail meta-card and verifies that the author profile page is opened. 