### PR TITLE
Skip login/logout tests because of an FxA bug

### DIFF
--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -2,7 +2,11 @@ import pytest
 
 from pages.desktop.home import Home
 
+# There was a bug introduced in FxA with the latest Nightly which breaks the
+# email input field - see details in https://github.com/mozilla/fxa/issues/8658
 
+
+@pytest.mark.skip(reason="Skipping because of an FxA bug")
 @pytest.mark.nondestructive
 def test_login(selenium, base_url):
     page = Home(selenium, base_url).open()
@@ -11,6 +15,7 @@ def test_login(selenium, base_url):
     assert user in page.header.user_display_name.text
 
 
+@pytest.mark.skip(reason="Skipping because of an FxA bug")
 @pytest.mark.nondestructive
 def test_logout(base_url, selenium):
     """User can logout"""


### PR DESCRIPTION
FxA bug that cased the test failures - https://github.com/mozilla/fxa/issues/8658