### PR TITLE
Minimize the amount of logs captured in the pytest html report

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
-addopts = -v --tb=long --showlocals
+addopts = -v
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true


### PR DESCRIPTION
This will make the pytest-html report easier to interpret. 