### PR TITLE
Add tests for user role badges

### DIFF
--- a/pages/desktop/static_pages.py
+++ b/pages/desktop/static_pages.py
@@ -1,0 +1,23 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+
+from pages.desktop.base import Base
+
+
+class StaticPages(Base):
+    """This class will store informative pages, such as 404 pages, server error pages
+    and other pages that have only an informative scope"""
+
+    _not_found_page_header_locator = (By.CLASS_NAME, 'Card-header-text')
+
+    def wait_for_page_to_load(self):
+        """Waits for various page components to be loaded"""
+        self.wait.until(
+            EC.invisibility_of_element_located((By.CLASS_NAME, 'LoadingText')),
+            message="The requested page could not be loaded",
+        )
+        return self
+
+    @property
+    def not_found_page_header(self):
+        return self.find_element(*self._not_found_page_header_locator).text

--- a/pages/desktop/users.py
+++ b/pages/desktop/users.py
@@ -41,6 +41,10 @@ class User(Base):
     class ViewProfile(Region):
         _user_icon_placeholder_locator = (By.CSS_SELECTOR, '.Icon-anonymous-user')
         _user_profile_image_locator = (By.CSS_SELECTOR, '.UserAvatar-image')
+        _user_developer_role_locator = (By.CSS_SELECTOR, '.UserProfile-developer')
+        _user_developer_role_icon_locator = (By.CSS_SELECTOR, '.Icon-developer')
+        _user_artist_role_locator = (By.CSS_SELECTOR, '.UserProfile-artist')
+        _user_artist_role_icon_locator = (By.CSS_SELECTOR, '.Icon-artist')
         _user_homepage_locator = (By.CSS_SELECTOR, '.UserProfile-homepage a')
         _user_location_locator = (By.CSS_SELECTOR, '.UserProfile-location')
         _user_occupation_locator = (By.CSS_SELECTOR, '.UserProfile-occupation')
@@ -64,6 +68,22 @@ class User(Base):
         @property
         def icon_source(self):
             return self.user_profile_icon.get_attribute('src')
+
+        @property
+        def developer_role(self):
+            return self.find_element(*self._user_developer_role_locator)
+
+        @property
+        def developer_role_icon(self):
+            return self.find_element(*self._user_developer_role_icon_locator)
+
+        @property
+        def artist_role(self):
+            return self.find_element(*self._user_artist_role_locator)
+
+        @property
+        def artist_role_icon(self):
+            return self.find_element(*self._user_artist_role_icon_locator)
 
         @property
         def user_homepage(self):

--- a/stage.json
+++ b/stage.json
@@ -3,6 +3,8 @@
 
   "search_term": "Flagfox",
 
+  "not_found_page_title": "Oops! We can’t find that page",
+
   "detail_extension_slug": "ghostery",
   "detail_extension_name": "Ghostery - Privacy Ad Blocker",
   "addon_with_stats": "facebook-container",
@@ -45,6 +47,11 @@
     "Mozilla needs to contact me about my individual add-on",
     "stay up-to-date with news and events relevant to add-on developers (including the about:addons newsletter)"
   ],
+  "developer_profile": "11687230",
+  "theme_artist_profile": "6199839",
+  "developer_and_artist_role": "11686381",
+  "non_developer_user": "11686961",
+
   "notifications_info_text": "From time to time, Mozilla may send you email about upcoming releases and add-on events. Please select the topics you are interested in.",
   "notifications_help_text": "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons."
 }


### PR DESCRIPTION
The View Profile page identifies developer and theme artist user roles with some badges. I've added these tests to make sure that badges are correctly applied. 

![image](https://user-images.githubusercontent.com/31961530/134512876-308ed4a7-a674-4946-963a-82ef8b3e5019.png)
