### PR TITLE
Upgrade windows orb and split serial jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 1
-          command: pytest test_collections.py --driver Firefox --variables stage.json --html=collections-test-results.html --self-contained-html
+          command: pytest tests\test_collections.py --driver Firefox --variables stage.json --html=collections-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: collections-test-results.html
@@ -51,7 +51,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 1
-          command: pytest test_ratings.py --driver Firefox --variables stage.json --html=ratings-test-results.html --self-contained-html
+          command: pytest tests\test_ratings.py --driver Firefox --variables stage.json --html=ratings-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: ratings-test-results.html
@@ -78,7 +78,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 1
-          command: pytest test_users.py --driver Firefox --variables stage.json --html=user-test-results.html --self-contained-html
+          command: pytest tests\test_users.py --driver Firefox --variables stage.json --html=user-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: user-test-results.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 version: 2.1
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@2.4.1
 jobs:
-  serial_tests:
+  # run collections tests in a separate serial job to make serial workflows more granular
+  collections_serial_tests:
     executor:
       name: win/default
       size: "medium"
@@ -19,15 +20,70 @@ jobs:
           name: Install Firefox
           command: choco install firefox-nightly --pre
       - run:
-          name: Run serial tests
+          name: Run collections serial tests
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 1
-          command: pytest -m "serial" --driver Firefox --variables stage.json --html=serial-test-results.html --self-contained-html
+          command: pytest test_collections.py --driver Firefox --variables stage.json --html=collections-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
-          path: serial-test-results.html
+          path: collections-test-results.html
 
+  # run ratings tests in a separate serial job to make serial workflows more granular
+  ratings_serial_tests:
+    executor:
+      name: win/default
+      size: "medium"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Install requirements
+          command: pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox-nightly --pre
+      - run:
+          name: Run ratings serial tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 1
+          command: pytest test_ratings.py --driver Firefox --variables stage.json --html=ratings-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: ratings-test-results.html
+
+  # run user tests in a separate serial job to make serial workflows more granular
+  user_serial_tests:
+    executor:
+      name: win/default
+      size: "medium"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Install requirements
+          command: pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox-nightly --pre
+      - run:
+          name: Run user serial tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 1
+          command: pytest test_users.py --driver Firefox --variables stage.json --html=user-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: user-test-results.html
+
+  # tests that do not require login; they include homepage, addon detail, search, addon landing pages, install and other misc tests
   parallel_tests:
     executor:
       name: win/default
@@ -57,7 +113,9 @@ jobs:
 workflows:
   commit_workflow:
     jobs:
-      - serial_tests
+      - collections_serial_tests
+      - ratings_serial_tests
+      - user_serial_tests
       - parallel_tests
   scheduled_stage_release_run:
     triggers:
@@ -68,5 +126,7 @@ workflows:
             branches:
               only: master
     jobs:
-      - serial_tests
+      - collections_serial_tests
+      - ratings_serial_tests
+      - user_serial_tests
       - parallel_tests

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,6 +4,7 @@ from pages.desktop.collections import Collections
 from scripts import reusables
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_collection_meta_card(selenium, base_url, variables):
     public_collection = variables['public_collection']
@@ -20,6 +21,7 @@ def test_collection_meta_card(selenium, base_url, variables):
     assert collection.collection_detail.collection_last_update_date.is_displayed()
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_collection_addon_count_is_correct(selenium, base_url, variables):
     public_collection = variables['public_collection']
@@ -56,6 +58,7 @@ def test_collection_creator_and_modified_date(selenium, base_url, variables, wai
     )
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_my_collections_page_items(selenium, base_url, variables):
     collections = Collections(selenium, base_url).open().wait_for_page_to_load()

--- a/tests/test_ratings.py
+++ b/tests/test_ratings.py
@@ -168,6 +168,7 @@ def test_delete_rating(selenium, base_url, variables):
     )
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_all_reviews_page_items(selenium, base_url, variables):
     extension = variables['detail_extension_slug']
@@ -181,6 +182,7 @@ def test_all_reviews_page_items(selenium, base_url, variables):
         assert review.posting_date.is_displayed()
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_filter_reviews_by_score(selenium, base_url, variables):
     extension = variables['all_scores_addon']
@@ -202,6 +204,7 @@ def test_filter_reviews_by_score(selenium, base_url, variables):
         count += 1
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_filter_reviews_from_rating_bars(selenium, base_url, variables):
     extension = variables['all_scores_addon']
@@ -222,6 +225,7 @@ def test_filter_reviews_from_rating_bars(selenium, base_url, variables):
         count += 1
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_flag_review_action(selenium, base_url, variables):
     extension = variables['all_scores_addon']
@@ -250,6 +254,7 @@ def test_flag_review_action(selenium, base_url, variables):
             count += 1
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_flag_missing_for_empty_review(selenium, base_url, variables):
     extension = variables['detail_extension_slug']
@@ -263,6 +268,7 @@ def test_flag_missing_for_empty_review(selenium, base_url, variables):
                 user_review.find_element(By.CSS_SELECTOR, '.FlagReviewMenu-menu')
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_flag_review_requires_login(selenium, base_url, variables):
     extension = variables['all_scores_addon']
@@ -282,6 +288,7 @@ def test_flag_review_requires_login(selenium, base_url, variables):
             count += 1
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_flag_review_menu_options(selenium, base_url, variables):
     extension = variables['all_scores_addon']

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -296,6 +296,7 @@ def test_user_mandatory_notifications(base_url, selenium):
         checkbox.is_selected()
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_developer_role(base_url, selenium, variables):
     developer = variables['developer_profile']
@@ -306,6 +307,7 @@ def test_user_developer_role(base_url, selenium, variables):
     assert user.view.developer_role_icon.is_displayed()
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_theme_artist_role(base_url, selenium, variables):
     artist = variables['theme_artist_profile']
@@ -316,6 +318,7 @@ def test_user_theme_artist_role(base_url, selenium, variables):
     assert user.view.artist_role_icon.is_displayed()
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_artist_and_developer_role(base_url, selenium, variables):
     dev_artist = variables['developer_and_artist_role']
@@ -328,6 +331,7 @@ def test_user_artist_and_developer_role(base_url, selenium, variables):
     assert user.view.artist_role_icon.is_displayed()
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_regular_has_no_role(base_url, selenium):
     user = User(selenium, base_url).open().wait_for_page_to_load()
@@ -338,6 +342,7 @@ def test_user_regular_has_no_role(base_url, selenium):
         selenium.find_element_by_css_selector('.UserProfile-developer')
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_non_developer_user_profile_is_not_public(base_url, selenium, variables):
     """Non developer users' profile pages are not publicly available;
@@ -352,6 +357,7 @@ def test_non_developer_user_profile_is_not_public(base_url, selenium, variables)
     ), f'The response status code was {response.status_code}'
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_profile_extensions_card(base_url, selenium, variables):
     page = variables['developer_and_artist_role']
@@ -382,6 +388,7 @@ def test_user_profile_extensions_card(base_url, selenium, variables):
             pytest.fail(exception.msg)
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_profile_themes_card(base_url, selenium, variables):
     page = variables['developer_and_artist_role']
@@ -409,6 +416,7 @@ def test_user_profile_themes_card(base_url, selenium, variables):
             pytest.fail(exception.msg)
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_profile_open_extension_detail_page(base_url, selenium, variables):
     page = variables['developer_profile']
@@ -421,6 +429,7 @@ def test_user_profile_open_extension_detail_page(base_url, selenium, variables):
     assert extension_name in detail_extension.name
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_profile_open_theme_detail_page(base_url, selenium, variables):
     artist = variables['theme_artist_profile']
@@ -499,6 +508,7 @@ def test_user_profile_delete_review(base_url, selenium, variables, wait):
     )
 
 
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_user_abuse_report(base_url, selenium, variables, wait):
     developer = variables['developer_profile']


### PR DESCRIPTION
In the past weeks, I've noticed some instability in the serial tests, with failures caused mostly by FxA being unresponsive (server errors, timeouts etc).

First, I've tried to mitigate that by adding more test users (see https://github.com/mozilla/addons-release-tests/pull/339), but it didn't work

Now, I'm trying to run the serial tests - which are requiring logins in most cases - in separate jobs based on the functionality tested. I'm hoping that by running separate jobs, which in turn are run in separate containers on CI, we're going to see some stability improvements, or, at least, isolate failing jobs more effectively. 

I've also upgraded the windows orb we were using, to the new 2.4.1 version. 