### PR TITLE
Try again to add pytest-rerunfailures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: Run collections serial tests
           environment:
             MOZ_HEADLESS: 1
-            PYTEST_ADDOPTS: -n 1
+            PYTEST_ADDOPTS: -n 1 --reruns 2
           command: pytest tests\test_collections.py --driver Firefox --variables stage.json --html=collections-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
@@ -50,7 +50,7 @@ jobs:
           name: Run ratings serial tests
           environment:
             MOZ_HEADLESS: 1
-            PYTEST_ADDOPTS: -n 1
+            PYTEST_ADDOPTS: -n 1 --reruns 2
           command: pytest tests\test_ratings.py --driver Firefox --variables stage.json --html=ratings-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
@@ -77,7 +77,7 @@ jobs:
           name: Run user serial tests
           environment:
             MOZ_HEADLESS: 1
-            PYTEST_ADDOPTS: -n 1
+            PYTEST_ADDOPTS: -n 1 --reruns 2
           command: pytest tests\test_users.py --driver Firefox --variables stage.json --html=user-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
@@ -104,7 +104,7 @@ jobs:
           name: Run parallel tests
           environment:
             MOZ_HEADLESS: 1
-            PYTEST_ADDOPTS: -n 4
+            PYTEST_ADDOPTS: -n 4 --reruns 2
           command: pytest -m "not serial" --driver Firefox --variables stage.json --html=parallel-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,13 +40,13 @@ PyPOM==2.2.0
 pytest==6.2.5
 pytest-base-url==1.4.2
 pytest-dependency==0.5.1
-pytest-depends==1.0.1
 pytest-firefox==0.1.1
 pytest-forked==1.3.0
 pytest-fxa==1.4.0
 pytest-html==3.1.1
 pytest-instafail==0.4.2
 pytest-metadata==1.11.0
+pytest-rerunfailures==10.2
 pytest-selenium==2.0.1
 pytest-variables==1.9.0
 pytest-xdist==2.4.0


### PR DESCRIPTION
I managed to make `pytest-rerunfailures` to run locally if I removed the `pytest-depends` dependency (which we are not using).
Let's see if it will work on CI as well. 