### PR TITLE
Tests for the devhub homepage main footer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           path: user-test-results.html
 
   # tests that do not require login; they include homepage, addon detail, search, addon landing pages, install and other misc tests
-  parallel_tests:
+  frontend_parallel_tests:
     executor:
       name: win/default
       size: "medium"
@@ -101,14 +101,41 @@ jobs:
           name: Install Firefox
           command: choco install firefox-nightly --pre
       - run:
-          name: Run parallel tests
+          name: Run frontend parallel tests
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 4 --reruns 2
-          command: pytest -m "not serial" --driver Firefox --variables stage.json --html=parallel-test-results.html --self-contained-html
+          command: pytest -m "not serial" --driver Firefox --variables stage.json --html=frontend-parallel-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
-          path: parallel-test-results.html
+          path: frontend-parallel-test-results.html
+
+  # tests that are covering the developer hub homepage
+  devhub_parallel_tests:
+    executor:
+      name: win/default
+      size: "medium"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Install requirements
+          command: pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox-nightly --pre
+      - run:
+          name: Run devhub parallel tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 4 --reruns 2
+          command: pytest tests\test_devhub.py --driver Firefox --variables stage.json --html=devhub-parallel-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: devhub-parallel-test-results.html
 
 workflows:
   commit_workflow:
@@ -116,7 +143,8 @@ workflows:
       - collections_serial_tests
       - ratings_serial_tests
       - user_serial_tests
-      - parallel_tests
+      - frontend_parallel_tests
+      - devhub_parallel_tests
   scheduled_stage_release_run:
     triggers:
       - schedule:
@@ -129,4 +157,5 @@ workflows:
       - collections_serial_tests
       - ratings_serial_tests
       - user_serial_tests
-      - parallel_tests
+      - frontend_parallel_tests
+      - devhub_parallel_tests

--- a/pages/desktop/devhub.py
+++ b/pages/desktop/devhub.py
@@ -1,0 +1,32 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
+
+from pages.desktop.base import Base
+
+
+class DevHub(Base):
+    """AMO Developer Hub homepage"""
+
+    URL_TEMPLATE = 'developers/'
+
+    _logo_locator = (By.CLASS_NAME, 'DevHub-Navigation-Logo')
+    _footer_language_picker_locator = (By.ID, 'language')
+    _footer_products_section_locator = (By.CSS_SELECTOR, '.Footer-products-links')
+    _footer_links_locator = (By.CSS_SELECTOR, '.Footer-links li a')
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda _: self.find_element(*self._logo_locator).is_displayed())
+        return self
+
+    @property
+    def page_logo(self):
+        return self.find_element(*self._logo_locator)
+
+    def footer_language_picker(self, value):
+        select = Select(self.find_element(*self._footer_language_picker_locator))
+        select.select_by_visible_text(value)
+
+    @property
+    def products_links(self):
+        element = self.find_element(*self._footer_products_section_locator)
+        return element.find_elements(*self._footer_links_locator)

--- a/tests/test_devhub.py
+++ b/tests/test_devhub.py
@@ -1,0 +1,163 @@
+import pytest
+
+from pages.desktop.devhub import DevHub
+
+
+@pytest.mark.nondestructive
+def test_devhub_mozilla_footer_link(base_url, selenium):
+    page = DevHub(selenium, base_url).open().wait_for_page_to_load()
+    page.footer.mozilla_link.click()
+    assert 'mozilla.org' in selenium.current_url
+
+
+@pytest.mark.parametrize(
+    'count, link',
+    enumerate(
+        [
+            'about',
+            'blog.mozilla.org',
+            'extensionworkshop',
+            'developers',
+            'add-on-policies',
+            'discourse',
+            '/about',
+            'review_guide',
+            'mozilla.org',  # temporary
+        ]
+    ),
+    ids=[
+        'DevHub Footer - Addons section -  About',
+        'DevHub Footer - Addons section -  Blog',
+        'DevHub Footer - Addons section -  Extension Workshop',
+        'DevHub Footer - Addons section -  Developer Hub',
+        'DevHub Footer - Addons section -  Developer Policies',
+        'DevHub Footer - Addons section -  Forum',
+        'DevHub Footer - Addons section -  Report a bug',
+        'DevHub Footer - Addons section -  Review Guide',
+        'DevHub Footer - Addons section -  Site status',
+    ],
+)
+@pytest.mark.nondestructive
+def test_devhub_addons_footer_links(base_url, selenium, count, link):
+    page = DevHub(selenium, base_url).open().wait_for_page_to_load()
+    page.footer.addon_links[count].click()
+    page.wait_for_current_url(link)
+
+
+@pytest.mark.parametrize(
+    'count, link',
+    enumerate(
+        [
+            'firefox/new',
+            'firefox/browsers/mobile/',
+            'mixedreality.mozilla.org',
+            'firefox/enterprise/',
+        ]
+    ),
+    ids=[
+        'DevHub Footer - Browsers section -  Desktop',
+        'DevHub Footer - Browsers section -  Mobile',
+        'DevHub Footer - Browsers section -  Reality',
+        'DevHub Footer - Browsers section -  Enterprise',
+    ],
+)
+@pytest.mark.nondestructive
+def test_devhub_browsers_footer_links(base_url, selenium, count, link):
+    page = DevHub(selenium, base_url).open().wait_for_page_to_load()
+    page.footer.browsers_links[count].click()
+    page.wait_for_current_url(link)
+
+
+@pytest.mark.parametrize(
+    'count, link',
+    enumerate(
+        [
+            'firefox/browsers/',
+            'products/vpn/',
+            'relay.firefox.com/',
+            'monitor.firefox',
+            'getpocket.com',
+        ]
+    ),
+    ids=[
+        'DevHub Footer - Products section -  Browsers',
+        'DevHub Footer - Products section -  VPN',
+        'DevHub Footer - Products section -  Relay',
+        'DevHub Footer - Products section -  Monitor',
+        'DevHub Footer - Products section -  Pocket',
+    ],
+)
+@pytest.mark.nondestructive
+def test_devhub_products_footer_links(base_url, selenium, count, link):
+    page = DevHub(selenium, base_url).open().wait_for_page_to_load()
+    page.products_links[count].click()
+    page.wait_for_current_url(link)
+
+
+@pytest.mark.parametrize(
+    'count, link',
+    enumerate(
+        [
+            'twitter.com',
+            'instagram.com',
+            'youtube.com',
+        ]
+    ),
+    ids=[
+        'DevHub Footer - Social section -  Twitter',
+        'DevHub Footer - Social section -  Instagram',
+        'DevHub Footer - Social section -  YouTube',
+    ],
+)
+@pytest.mark.nondestructive
+def test_devhub_social_footer_links(base_url, selenium, count, link):
+    page = DevHub(selenium, base_url).open().wait_for_page_to_load()
+    page.footer.social_links[count].click()
+    page.wait_for_current_url(link)
+
+
+@pytest.mark.parametrize(
+    'count, link',
+    enumerate(
+        [
+            'privacy/websites/',
+            'privacy/websites/',
+            'legal/terms/mozilla',
+        ]
+    ),
+    ids=[
+        'DevHub Footer - Legal section -  Privacy',
+        'DevHub Footer - Legal section -  Cookies',
+        'DevHub Footer - Legal section -  Legal',
+    ],
+)
+@pytest.mark.nondestructive
+def test_devhub_legal_footer_links(base_url, selenium, count, link):
+    page = DevHub(selenium, base_url).open().wait_for_page_to_load()
+    page.footer.legal_links[count].click()
+    page.wait_for_current_url(link)
+
+
+@pytest.mark.parametrize(
+    'language, locale, translation',
+    [
+        ('Français', 'fr', 'Pôle développeurs de modules'),
+        ('Deutsch', 'de', 'Add-on-Entwicklerzentrum'),
+        ('中文 (简体)', 'zh-CN', '附加组件开发者中心'),
+        ('Русский', 'ru', 'Разработчикам дополнений'),
+        ('עברית', 'he', 'מרכז מפתחי תוספות'),
+    ],
+    ids=[
+        'DevHub French Translation',
+        'DevHub German Translation',
+        'DevHub Chinese Translation',
+        'DevHub Russian Translation',
+        'DevHub Hebrew Translation',
+    ],
+)
+@pytest.mark.nondestructive
+def test_change_devhub_language(base_url, selenium, language, locale, translation):
+    page = DevHub(selenium, base_url).open().wait_for_page_to_load()
+    page.footer_language_picker(language)
+    assert f'{locale}/developers/' in selenium.current_url
+    assert translation in page.page_logo.text


### PR DESCRIPTION
Started adding test for the Developer Hub homepage with the main footer, which is a tedious process to be tested manually every week.

Devhub tests will run in a separate job, so I've added it to the config.