### PR TITLE
limit dependabot PRs to one per day to avoid concurrent runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Allow only one open pull request at a time for pip dependencies in order to prevent concurrent jobs;
+    # for context: we have tests that are strictly interdependent so, if the same test is being run in
+    # multiple concurrent jobs, there is a high risk of failure
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Based on https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit - this should only trigger one PR from dependabot per day. 