### PR TITLE
Modify windowhandles methods to work with selenium 4

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -278,7 +278,7 @@ class Header(Region):
             message=f'Number of windows was {len(self.selenium.window_handles)}, expected 2',
         )
         new_tab = self.selenium.window_handles[1]
-        self.selenium.switch_to_window(new_tab)
+        self.selenium.switch_to.window(new_tab)
         self.wait.until(
             EC.visibility_of_element_located((By.CLASS_NAME, 'DevHub-Navigation-Logo')),
             message=f'DevHub homepage not loaded; page was {self.selenium.current_url}',
@@ -291,7 +291,7 @@ class Header(Region):
             message=f'Number of windows was {len(self.selenium.window_handles)}, expected 2',
         )
         new_tab = self.selenium.window_handles[1]
-        self.selenium.switch_to_window(new_tab)
+        self.selenium.switch_to.window(new_tab)
         self.wait.until(
             EC.visibility_of_element_located((By.CLASS_NAME, 'logo')),
             message=f'Extension Workshop not loaded; page was {self.selenium.current_url}',

--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -99,7 +99,7 @@ class Detail(Base):
         self.promoted_badge.click()
         self.wait.until(expected.number_of_windows_to_be(2))
         new_tab = self.selenium.window_handles[1]
-        self.selenium.switch_to_window(new_tab)
+        self.selenium.switch_to.window(new_tab)
         self.wait.until(
             expected.visibility_of_element_located((By.CLASS_NAME, 'sumo-page-heading'))
         )
@@ -133,7 +133,7 @@ class Detail(Base):
         self.find_element(*self._install_warning_button_locator).click()
         self.wait.until(expected.number_of_windows_to_be(2))
         new_tab = self.selenium.window_handles[1]
-        self.selenium.switch_to_window(new_tab)
+        self.selenium.switch_to.window(new_tab)
         self.wait.until(
             expected.visibility_of_element_located((By.CLASS_NAME, 'sumo-page-heading'))
         )
@@ -262,7 +262,7 @@ class Detail(Base):
             self.find_element(*self._contribute_button_locator).click()
             self.wait.until(expected.number_of_windows_to_be(2))
             new_tab = self.selenium.window_handles[1]
-            self.selenium.switch_to_window(new_tab)
+            self.selenium.switch_to.window(new_tab)
 
     class Permissions(Region):
         _permissions_header_locator = (By.CSS_SELECTOR, '.PermissionsCard header')
@@ -285,7 +285,7 @@ class Detail(Base):
             self.find_element(*self._permissions_learn_more_locator).click()
             self.wait.until(expected.number_of_windows_to_be(2))
             new_tab = self.selenium.window_handles[1]
-            self.selenium.switch_to_window(new_tab)
+            self.selenium.switch_to.window(new_tab)
 
         class PermissionDetails(Region):
             _permission_icon_locator = (By.CSS_SELECTOR, '.Permission .Icon')

--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -95,7 +95,7 @@ class Home(Base):
             link[count].click()
             self.wait.until(EC.number_of_windows_to_be(2))
             new_tab = self.selenium.window_handles[1]
-            self.selenium.switch_to_window(new_tab)
+            self.selenium.switch_to.window(new_tab)
             # see more external links can contain variable content we might not know in advance (especially on prod)
             # the solution used here is to verify that the content we link to is available (i.e. page response = 200)
             self.wait.until(custom_waits.url_not_contins('about:blank'))
@@ -104,7 +104,7 @@ class Home(Base):
                 page.status_code == 200
             ), f'The response status code was {page.status_code}'
             self.selenium.close()
-            self.selenium.switch_to_window(home_tab)
+            self.selenium.switch_to.window(home_tab)
         else:
             # similar to external links, internal links might contain unpredictable content;
             # in this case, we check that the content exists inside the AMO domain
@@ -324,7 +324,7 @@ class Home(Base):
                     link.click()
                     self.wait.until(EC.number_of_windows_to_be(2))
                     new_tab = self.selenium.window_handles[1]
-                    self.selenium.switch_to_window(new_tab)
+                    self.selenium.switch_to.window(new_tab)
                     # editorial might change these links when they need to push new content and we don't know
                     # in advance what that content might be; also, we want to avoid frequent maintenance for
                     # these tests; the solution used is to verify that the content we link to is available

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ pytest-variables==1.9.0
 pytest-xdist==2.4.0
 regex==2021.11.10
 requests==2.26.0
-selenium==3.141.0
+selenium==4.0.0
 six==1.16.0
 tenacity==8.0.1
 toml==0.10.2


### PR DESCRIPTION
Now that `pypom` has been upgraded to be compatible with selenium 4, I was able to run the tests with the new selenium version and noticed that the `switch_to_window` option is no longer supported. I've updated the methods that rely on that function to be compatible with selenium 4.