### PR TITLE
Add fxa register methods and test

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -92,6 +92,14 @@ class Base(Page):
             message=f'Log in flow was not successful. URL at fail time was {self.selenium.current_url}',
         )
 
+    def register(self):
+        fxa_register_page = self.header.click_login()
+        self.wait.until(EC.visibility_of_element_located((By.NAME, 'email')))
+        fxa_register_page.fxa_register()
+        # wait for transition between FxA page and AMO
+        self.wait.until(EC.url_contains('addons'))
+        self.wait.until(lambda _: self.logged_in)
+
     def logout(self):
         self.header.click_logout()
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -37,6 +37,17 @@ def test_logout(base_url, selenium):
 
 @pytest.mark.serial
 @pytest.mark.nondestructive
+def test_register(base_url, selenium, wait):
+    page = Home(selenium, base_url).open().wait_for_page_to_load()
+    page.register()
+    # reassign AMO homepage it to another variable because 'page' can become stale at this point
+    username = Home(selenium, base_url).wait_for_page_to_load()
+    # check that a new user has been created (default user prefix should be 'Firefox user')
+    username.header.user_header_display_name('Firefox user')
+
+
+@pytest.mark.serial
+@pytest.mark.nondestructive
 def test_user_menu_collections_link(base_url, selenium):
     page = Home(selenium, base_url).open().wait_for_page_to_load()
     page.login('regular_user')


### PR DESCRIPTION
I've added two methods to handle new account registration:
- a method that accesses the `restmail` endpoint to get the fxa verification code
- a method that handles the FxA registration form input

