### PR TITLE
Skip a test due to an AMO bug and limit traceback logs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
-addopts = -v --tb=long
+addopts = -v
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -387,6 +387,7 @@ def test_delete_collection(selenium, base_url, variables):
     assert collection_name not in [el.name for el in collections.list]
 
 
+@pytest.mark.skip(reason='Skipping test until a bug in the collection form is fixed')
 @pytest.mark.serial
 @pytest.mark.nondestructive
 def test_create_collection_from_addon_detail_page(selenium, base_url, variables, wait):


### PR DESCRIPTION
- skip a collection test until an issue with the collection form on AMO is fixed
- reduce amount of logs captured