### PR TITLE
Migrate CircleCI scheduled runs to the new scheduling model

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,13 +184,6 @@ workflows:
       - frontend_parallel_tests
       - devhub_parallel_tests
   scheduled_stage_release_run:
-    triggers:
-      - schedule:
-          # the workflow runs each Wednesday at 05:00 UTC
-          cron: "0 5 * * 3"
-          filters:
-            branches:
-              only: master
     jobs:
       - collections_serial_tests
       - ratings_serial_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,9 @@ workflows:
       - frontend_parallel_tests
       - devhub_parallel_tests
   scheduled_stage_release_run:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - collections_serial_tests
       - ratings_serial_tests


### PR DESCRIPTION
CircleCi will  deprecate scheduling workflows directly within [.circleci/config.yml](https://github.com/mozilla/addons-release-tests/compare/migrate-circleci-scheduled-jobs?expand=1#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47).
They have added a different method for scheduling pipelines, as explained in https://circleci.com/docs/2.0/scheduled-pipelines/#get-started

I've set up the `scheduled_stage_release_run` trigger in the CircleCI Project settings and, hopefully, our scheduled release run will continue to run fine on Wednesdays at the established hour. 