### PR TITLE
Initial setup for sanity tests run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,9 @@ jobs:
 
 workflows:
   commit_workflow:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - collections_serial_tests
       - ratings_serial_tests
@@ -255,6 +258,7 @@ workflows:
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "scheduled_stage_release_run", << pipeline.schedule.name >> ]
     jobs:
       - collections_serial_tests
       - ratings_serial_tests
@@ -265,6 +269,7 @@ workflows:
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "scheduled_prod_sanity_run", << pipeline.schedule.name >> ]
     jobs:
       - sanity_parallel_tests
       - sanity_serial_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,11 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "scheduled_prod_sanity_run", << pipeline.schedule.name >> ]
     jobs:
-      - sanity_parallel_tests
-      - sanity_serial_tests
       - hold: # this job needs to be started manually once all the push duty tasks have been completed by AMO ops
           type: approval
+      - sanity_parallel_tests:
+          requires:
+            - hold
+      - sanity_serial_tests:
+          requires:
+            - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 4 --reruns 2
-          command: pytest tests\frontend -m "not serial" --driver Firefox --variables stage.json --html=frontend-parallel-test-results.html --self-contained-html
+          command: pytest tests\frontend -m "not serial and not prod_only" --driver Firefox --variables stage.json --html=frontend-parallel-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: frontend-parallel-test-results.html
@@ -175,6 +175,74 @@ jobs:
       - store_artifacts:
           path: devhub-parallel-test-results.html
 
+  # parallel tests run on production after the AMO push
+  sanity_parallel_tests:
+    executor:
+      name: win/default
+      version: "previous"
+      size: "medium"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Install python 3.9
+          command: choco install python --version=3.9.0
+      - run:
+          name: Upgrade pip
+          command: pip install --upgrade pip --user
+      - run:
+          name: Install requirements
+          command: pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox
+      - run:
+          name: Sanity parallel tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 4 --reruns 2
+          command: pytest -m "prod_only or sanity and not serial" --driver Firefox --variables prod.json --html=sanity-parallel-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: sanity-parallel-test-results.html
+
+  # serial tests run on production after the AMO push
+  sanity_serial_tests:
+    executor:
+      name: win/default
+      version: "previous"
+      size: "medium"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Install python 3.9
+          command: choco install python --version=3.9.0
+      - run:
+          name: Upgrade pip
+          command: pip install --upgrade pip --user
+      - run:
+          name: Install requirements
+          command: pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox
+      - run:
+          name: Sanity serial tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 1 --reruns 2
+          command: pytest -m "sanity and serial" --driver Firefox --variables prod.json --html=sanity-serial-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: sanity-serial-test-results.html
+
 workflows:
   commit_workflow:
     jobs:
@@ -193,3 +261,12 @@ workflows:
       - user_serial_tests
       - frontend_parallel_tests
       - devhub_parallel_tests
+  scheduled_prod_sanity_run:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - sanity_parallel_tests
+      - sanity_serial_tests
+      - hold: # this job needs to be started manually once all the push duty tasks have been completed by AMO ops
+          type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,7 @@ workflows:
       - user_serial_tests
       - frontend_parallel_tests
       - devhub_parallel_tests
+  # scheduled in CircleCI Project settings to run each Wednesdays at 05:00 UTC
   scheduled_stage_release_run:
     when:
       and:
@@ -265,17 +266,20 @@ workflows:
       - user_serial_tests
       - frontend_parallel_tests
       - devhub_parallel_tests
+  # scheduled in CircleCI Project settings to start each Thursdays at 17:00 UTC
   scheduled_prod_sanity_run:
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "scheduled_prod_sanity_run", << pipeline.schedule.name >> ]
     jobs:
-      - hold: # this job needs to be started manually once all the push duty tasks have been completed by AMO ops
+      # this job needs to be Approved in the CircleCI app in order to trigger the next job runs
+      # once all the push duty tasks have been completed by AMO ops
+      - hold:
           type: approval
-      - sanity_parallel_tests:
+      - sanity_parallel_tests: # will run after the hold job is approved
           requires:
             - hold
-      - sanity_serial_tests:
+      - sanity_serial_tests: # # will run after the hold job is approved
           requires:
             - hold

--- a/pages/desktop/frontend/language_tools.py
+++ b/pages/desktop/frontend/language_tools.py
@@ -1,0 +1,46 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+
+from pages.desktop.base import Base
+
+
+class LanguageTools(Base):
+    URL_TEMPLATE = '/language-tools/'
+
+    _language_tools_header_locator = (By.CLASS_NAME, 'Card-header-text')
+    _langpacks_info_text_locator = (By.CSS_SELECTOR, '.Card-contents p:nth-child(2)')
+    _dictionaries_info_text_locator = (By.CSS_SELECTOR, '.Card-contents p:nth-child(1)')
+    _language_list_column_locator = (By.CSS_SELECTOR, '.pivoted:nth-child(1) strong')
+    _langpacks_list_column_locator = (By.CSS_SELECTOR, '.pivoted:nth-child(2) a')
+    _dictionaries_list_column_locator = (By.CSS_SELECTOR, '.pivoted:nth-child(3) a')
+
+    def loaded(self):
+        """Waits for various page components to be loaded"""
+        self.wait.until(
+            EC.invisibility_of_element_located((By.CLASS_NAME, 'LoadingText'))
+        )
+        return self
+
+    @property
+    def language_tools_header(self):
+        return self.find_element(*self._language_tools_header_locator).text
+
+    @property
+    def language_packs_info_text(self):
+        return self.find_element(*self._langpacks_info_text_locator).text
+
+    @property
+    def dictionaries_info_text(self):
+        return self.find_element(*self._dictionaries_info_text_locator).text
+
+    @property
+    def supported_languages_list(self):
+        return self.find_elements(*self._language_list_column_locator)
+
+    @property
+    def available_language_packs(self):
+        return self.find_elements(*self._langpacks_list_column_locator)
+
+    @property
+    def available_dictionaries(self):
+        return self.find_elements(*self._dictionaries_list_column_locator)

--- a/prod.json
+++ b/prod.json
@@ -1,3 +1,10 @@
 {
-  "base_url": "https://addons.mozilla.org/"
+  "base_url": "https://addons.mozilla.org/",
+
+  "install_extension": "ghostery",
+  "install_theme": "matte-black-red",
+
+  "language_tools_page_header": "Dictionaries and Language Packs",
+  "language_packs_info": "Language packs change your browser's interface language, including menu options and settings.",
+  "dictionaries_info": "Installing a dictionary add-on will add a new language option to your spell-checker, which checks your spelling as you type in Firefox."
 }

--- a/prod.json
+++ b/prod.json
@@ -4,6 +4,9 @@
   "install_extension": "ghostery",
   "install_theme": "matte-black-red",
 
+  "public_collection": "/4757633/privacy-matters/",
+  "public_collection_name": "Privacy Matters",
+
   "language_tools_page_header": "Dictionaries and Language Packs",
   "language_packs_info": "Language packs change your browser's interface language, including menu options and settings.",
   "dictionaries_info": "Installing a dictionary add-on will add a new language option to your spell-checker, which checks your spelling as you type in Firefox."

--- a/stage.json
+++ b/stage.json
@@ -72,6 +72,10 @@
   "collection_reused_url_warning": "This custom URL is already in use by another one of your collections.",
   "collection_invalid_custom_url_warning": "The custom URL must consist of letters, numbers, underscores or hyphens.",
 
+  "language_tools_page_header": "Dictionaries and Language Packs",
+  "language_packs_info": "Language packs change your browser's interface language, including menu options and settings.",
+  "dictionaries_info": "Installing a dictionary add-on will add a new language option to your spell-checker, which checks your spelling as you type in Firefox.",
+
   "devhub_overview_header": "Customize Firefox",
   "devhub_overview_summary": "Whether you’re new to extension development, polishing up or porting an existing extension or theme, or creating a custom enterprise solution, we’ve got the resources to support you.",
   "devhub_content_header": "Ready to submit or manage your extension?",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,11 +39,11 @@ def firefox_options(firefox_options, request):
 
     """
     # for prod installation tests, we do not need to set special prefs,
-    # so I've added a custom marker to which will allow the Firefox
+    # so I've added a custom marker which will allow the Firefox
     # driver to run a clean profile for prod tests, when necessary
     marker = request.node.get_closest_marker('firefox_release')
     if marker:
-        firefox_options.add_argument('-foreground')
+        firefox_options.add_argument('-headless')
         firefox_options.log.level = 'trace'
     else:
         firefox_options.set_preference('extensions.install.requireBuiltInCerts', False)
@@ -65,7 +65,7 @@ def firefox_notifications(notifications):
 @pytest.fixture(
     scope='function',
     params=[DESKTOP],
-    ids=[''],
+    ids=['Desktop'],
 )
 def selenium(selenium, request):
     """Fixture to set a custom resolution for tests running on Desktop."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def sensitive_url(request, base_url):
 
 
 @pytest.fixture
-def firefox_options(firefox_options):
+def firefox_options(firefox_options, request):
     """Firefox options.
 
     These options configure firefox to allow for addon installation,
@@ -38,14 +38,22 @@ def firefox_options(firefox_options):
     '-headless': Firefox will run headless
 
     """
-    firefox_options.set_preference('extensions.install.requireBuiltInCerts', False)
-    firefox_options.set_preference('xpinstall.signatures.required', False)
-    firefox_options.set_preference('xpinstall.signatures.dev-root', True)
-    firefox_options.set_preference('extensions.webapi.testing', True)
-    firefox_options.set_preference('ui.popup.disable_autohide', True)
-    firefox_options.set_preference('devtools.console.stdout.content', True)
-    firefox_options.add_argument('-headless')
-    firefox_options.log.level = 'trace'
+    # for prod installation tests, we do not need to set special prefs,
+    # so I've added a custom marker to which will allow the Firefox
+    # driver to run a clean profile for prod tests, when necessary
+    marker = request.node.get_closest_marker('firefox_release')
+    if marker:
+        firefox_options.add_argument('-foreground')
+        firefox_options.log.level = 'trace'
+    else:
+        firefox_options.set_preference('extensions.install.requireBuiltInCerts', False)
+        firefox_options.set_preference('xpinstall.signatures.required', False)
+        firefox_options.set_preference('xpinstall.signatures.dev-root', True)
+        firefox_options.set_preference('extensions.webapi.testing', True)
+        firefox_options.set_preference('ui.popup.disable_autohide', True)
+        firefox_options.set_preference('devtools.console.stdout.content', True)
+        firefox_options.add_argument('-headless')
+        firefox_options.log.level = 'trace'
     return firefox_options
 
 
@@ -57,7 +65,7 @@ def firefox_notifications(notifications):
 @pytest.fixture(
     scope='function',
     params=[DESKTOP],
-    ids=['Resolution: 1920x1080'],
+    ids=[''],
 )
 def selenium(selenium, request):
     """Fixture to set a custom resolution for tests running on Desktop."""

--- a/tests/frontend/test_collections.py
+++ b/tests/frontend/test_collections.py
@@ -12,6 +12,7 @@ from scripts import reusables
 
 
 @pytest.mark.serial
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_collection_meta_card(selenium, base_url, variables):
     public_collection = variables['public_collection']

--- a/tests/frontend/test_sanity.py
+++ b/tests/frontend/test_sanity.py
@@ -1,0 +1,99 @@
+import pytest
+import random
+
+from pages.desktop.frontend.details import Detail
+from pages.desktop.frontend.language_tools import LanguageTools
+
+
+# For the scope of each of the custom markers used for sanity tests, see the pytest.ini file
+
+
+@pytest.mark.nondestructive
+@pytest.mark.prod_only
+def test_language_tools_landing_page(selenium, base_url, variables):
+    page = LanguageTools(selenium, base_url).open().wait_for_page_to_load()
+    # verify the information present on the landing page
+    assert variables['language_tools_page_header'] in page.language_tools_header
+    assert variables['dictionaries_info'] in page.dictionaries_info_text
+    assert variables['language_packs_info'] in page.language_packs_info_text
+    # we don't always know the number of supported languages in advance,
+    # but we can make sure we are in close range to what we always supported
+    assert len(page.supported_languages_list) in range(120, 140)
+
+
+@pytest.mark.nondestructive
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_install_language_pack(
+    selenium, base_url, variables, firefox, firefox_notifications
+):
+    page = LanguageTools(selenium, base_url).open().wait_for_page_to_load()
+    lang_packs_list = page.available_language_packs
+    # pick a random language pack from the list and install it
+    random.choice(lang_packs_list).click()
+    lang_pack_detail = Detail(selenium, base_url).wait_for_page_to_load()
+    lang_pack_detail.install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    assert 'Remove' in lang_pack_detail.button_text
+    # uninstall the language pack and check that install button changes state
+    lang_pack_detail.install()
+    assert 'Add to Firefox' in lang_pack_detail.button_text
+
+
+@pytest.mark.sanity
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_install_dictionary(
+    selenium, base_url, variables, firefox, firefox_notifications
+):
+    page = LanguageTools(selenium, base_url).open().wait_for_page_to_load()
+    dictionaries_list = page.available_dictionaries
+    # pick a random dictionary from the list and install it
+    random.choice(dictionaries_list).click()
+    dictionary_detail = Detail(selenium, base_url).wait_for_page_to_load()
+    dictionary_detail.install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    assert 'Remove' in dictionary_detail.button_text
+    # uninstall the dictionary and check that install button changes state
+    dictionary_detail.install()
+    assert 'Add to Firefox' in dictionary_detail.button_text
+
+
+@pytest.mark.sanity
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_install_extension(
+    selenium, base_url, variables, firefox, firefox_notifications
+):
+    extension = variables['install_extension']
+    selenium.get(f'{base_url}/addon/{extension}')
+    addon = Detail(selenium, base_url).wait_for_page_to_load()
+    addon.install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    assert 'Remove' in addon.button_text
+    # uninstall the extension and check that install button changes state
+    addon.install()
+    assert 'Add to Firefox' in addon.button_text
+
+
+@pytest.mark.sanity
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_install_theme(selenium, base_url, variables, firefox, firefox_notifications):
+    extension = variables['install_theme']
+    selenium.get(f'{base_url}/addon/{extension}')
+    addon = Detail(selenium, base_url).wait_for_page_to_load()
+    addon.install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    assert 'Remove' in addon.button_text
+    # uninstall the theme and check that install button changes state
+    addon.install()
+    assert 'Install Theme' in addon.button_text


### PR DESCRIPTION
Included in this PR:

- CircleCi configs for prod tests
- updated firefox capabilities to use e clean profile when running prod install tests
- added page objects for the Language Tools page
- added install tests to be run on production with data available there

Note that the sanity tests added so far were mostly used as a trial run for the CircleCI set-up (new jobs for sanity runs, scheduling jobs, holding jobs for approval)

Once I'm happy with the system, I'm going to select other strategic tests, from the ones we already have, to be included in the sanity runs - they will be marked with `pytest.mark.sanity`.