### PR TITLE
Add tests for search filters combinations

### DIFF
--- a/pages/desktop/frontend/search.py
+++ b/pages/desktop/frontend/search.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from pypom import Page, Region
 
 from selenium.webdriver.common.by import By
@@ -112,14 +110,6 @@ class Search(Page):
             from pages.desktop.frontend.details import Detail
 
             return Detail(self.selenium, self.page.base_url).wait_for_page_to_load()
-
-        def validate_filter_sort_by_rating(self):
-            for result in self.extensions:
-                assert getattr(result, 'rating') > 4
-
-        def validate_filter_sort_by_users(self):
-            results = [getattr(result, 'users') for result in self.extensions]
-            assert sorted(results, reverse=True) == results
 
         class ResultListItems(Region):
             _rating_locator = (By.CSS_SELECTOR, '.Rating--small')

--- a/pages/desktop/frontend/search.py
+++ b/pages/desktop/frontend/search.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pypom import Page, Region
 
 from selenium.webdriver.common.by import By
@@ -111,6 +113,14 @@ class Search(Page):
 
             return Detail(self.selenium, self.page.base_url).wait_for_page_to_load()
 
+        def validate_filter_sort_by_rating(self):
+            for result in self.extensions:
+                assert getattr(result, 'rating') > 4
+
+        def validate_filter_sort_by_users(self):
+            results = [getattr(result, 'users') for result in self.extensions]
+            assert sorted(results, reverse=True) == results
+
         class ResultListItems(Region):
             _rating_locator = (By.CSS_SELECTOR, '.Rating--small')
             _search_item_name_locator = (By.CSS_SELECTOR, '.SearchResult-link')
@@ -123,10 +133,13 @@ class Search(Page):
                 return self.find_element(*self._search_item_name_locator).text
 
             def link(self):
+                self.wait.until(
+                    EC.element_to_be_clickable(self._search_item_name_locator)
+                )
                 self.find_element(*self._search_item_name_locator).click()
                 from pages.desktop.frontend.details import Detail
 
-                detail_page = Detail(self.selenium, self.page.base_url)
+                detail_page = Detail(self.selenium, self.page.page.base_url)
                 return detail_page.wait_for_page_to_load()
 
             @property

--- a/tests/frontend/test_search.py
+++ b/tests/frontend/test_search.py
@@ -282,79 +282,107 @@ def test_filter_extensions(base_url, selenium):
     assert len(search_page.result_list.themes) == 0
 
 
-@pytest.mark.parametrize(
-    'addon_type, badge',
-    [
-        ('All', 'Recommended'),
-        ('Extension', 'Recommended'),
-        ('Theme', 'Recommended'),
-    ],
-)
 @pytest.mark.nondestructive
-def test_sort_rating_combinations(base_url, selenium, variables, addon_type, badge):
+def test_top_rated_recommended_addons(base_url, selenium, variables):
     page = Home(selenium, base_url).open()
     search_page = page.search.search_for(variables['search_term'])
     # apply filters and then search again
     Select(search_page.filter_by_sort).select_by_visible_text('Top Rated')
-    Select(search_page.filter_by_type).select_by_visible_text(addon_type)
-    Select(search_page.filter_by_badging).select_by_visible_text(badge)
+    Select(search_page.filter_by_type).select_by_visible_text('All')
+    Select(search_page.filter_by_badging).select_by_visible_text('Recommended')
     page.search.search_field.clear()
     page.search.search_for('')
-    # verify if elements are correctly sorted
-    search_page.result_list.validate_filter_sort_by_rating()
-    # verify that only the wanted add-on type is showed
-    if addon_type == 'Extension':
-        # verify that no themes are displayed
-        assert len(search_page.result_list.themes) == 0
-    elif addon_type == 'Theme':
-        # verify that all elements displayed are themes
-        assert len(search_page.result_list.themes) == len(
-            search_page.result_list.extensions
-        )
+    # verify if sort filter applied correctly
+    for result in search_page.result_list.extensions:
+        assert getattr(result, 'rating') > 4
     # verify badge type
     results = search_page.result_list.extensions
     for result in results:
-        assert badge in result.promoted_badge_label
+        assert 'Recommended' in result.promoted_badge_label
 
 
-@pytest.mark.parametrize(
-    'addon_type, badge',
-    [
-        ('All', 'Recommended'),
-        ('All', 'By Firefox'),
-        ('Extension', 'Recommended'),
-        ('Extension', 'By Firefox'),
-        ('Extension', 'Any'),
-        ('Theme', 'Recommended'),
-        ('Theme', 'By Firefox'),
-        ('Theme', 'Any'),
-    ],
-)
 @pytest.mark.nondestructive
-def test_sort_users_combinations(base_url, selenium, variables, addon_type, badge):
+def test_top_rated_recommended_extensions(base_url, selenium, variables):
+    page = Home(selenium, base_url).open()
+    search_page = page.search.search_for(variables['search_term'])
+    # apply filters and then search again
+    Select(search_page.filter_by_sort).select_by_visible_text('Top Rated')
+    Select(search_page.filter_by_type).select_by_visible_text('Extension')
+    Select(search_page.filter_by_badging).select_by_visible_text('Recommended')
+    page.search.search_field.clear()
+    page.search.search_for('')
+    # verify if sort filter applied correctly
+    for result in search_page.result_list.extensions:
+        assert getattr(result, 'rating') > 4
+    # verify that no themes are displayed
+    assert len(search_page.result_list.themes) == 0
+    # verify badge type
+    results = search_page.result_list.extensions
+    for result in results:
+        assert 'Recommended' in result.promoted_badge_label
+
+
+@pytest.mark.nondestructive
+def test_top_rated_recommended_themes(base_url, selenium, variables):
+    page = Home(selenium, base_url).open()
+    search_page = page.search.search_for(variables['search_term'])
+    # apply filters and then search again
+    Select(search_page.filter_by_sort).select_by_visible_text('Top Rated')
+    Select(search_page.filter_by_type).select_by_visible_text('Theme')
+    Select(search_page.filter_by_badging).select_by_visible_text('Recommended')
+    page.search.search_field.clear()
+    page.search.search_for('')
+    # verify if sort filter applied correctly
+    for result in search_page.result_list.extensions:
+        assert getattr(result, 'rating') > 4
+    # verify that all elements are themes
+    assert len(search_page.result_list.themes) == len(
+        search_page.result_list.extensions
+    )
+    # verify badge type
+    results = search_page.result_list.extensions
+    for result in results:
+        assert 'Recommended' in result.promoted_badge_label
+
+
+@pytest.mark.nondestructive
+def test_most_users_recommended_addons(base_url, selenium, variables):
     page = Home(selenium, base_url).open()
     search_page = page.search.search_for('')
     # apply filters and then search term
     Select(search_page.filter_by_sort).select_by_visible_text('Most Users')
-    Select(search_page.filter_by_type).select_by_visible_text(addon_type)
-    Select(search_page.filter_by_badging).select_by_visible_text(badge)
+    Select(search_page.filter_by_type).select_by_visible_text('All')
+    Select(search_page.filter_by_badging).select_by_visible_text('Recommended')
     page.search.search_for(variables['search_term'])
     # verify if elements are correctly sorted
-    search_page.result_list.validate_filter_sort_by_users()
-    # verify that only the wanted add-on type is showed
-    if addon_type == 'Extension':
-        # verify that no themes are displayed
-        assert len(search_page.result_list.themes) == 0
-    elif addon_type == 'Theme':
-        # verify that all elements displayed are themes
-        assert len(search_page.result_list.themes) == len(
-            search_page.result_list.extensions
-        )
+    results = [
+        getattr(result, 'users') for result in search_page.result_list.extensions
+    ]
+    assert sorted(results, reverse=True) == results
     # verify badge type
     results = search_page.result_list.extensions
-    if badge != 'Any':
-        for result in results:
-            assert badge in result.promoted_badge_label
+    for result in results:
+        assert 'Recommended' in result.promoted_badge_label
+
+
+@pytest.mark.nondestructive
+def test_most_users_by_firefox_addons(base_url, selenium, variables):
+    page = Home(selenium, base_url).open()
+    search_page = page.search.search_for('')
+    # apply filters and then search term
+    Select(search_page.filter_by_sort).select_by_visible_text('Most Users')
+    Select(search_page.filter_by_type).select_by_visible_text('All')
+    Select(search_page.filter_by_badging).select_by_visible_text('By Firefox')
+    page.search.search_for(variables['search_term'])
+    # verify if elements are correctly sorted
+    results = [
+        getattr(result, 'users') for result in search_page.result_list.extensions
+    ]
+    assert sorted(results, reverse=True) == results
+    # verify badge type
+    results = search_page.result_list.extensions
+    for result in results:
+        assert 'By Firefox' in result.promoted_badge_label
 
 
 @pytest.mark.nondestructive

--- a/tests/frontend/test_search.py
+++ b/tests/frontend/test_search.py
@@ -283,6 +283,58 @@ def test_filter_extensions(base_url, selenium):
 
 
 @pytest.mark.nondestructive
+def test_filter_recommended_extensions_sort_by_users(base_url, selenium, variables):
+    page = Home(selenium, base_url).open()
+    term = 'fox'
+    sort = 'users'
+    addon_type = 'extension'
+    promoted = 'recommended'
+    selenium.get(f'{base_url}/search/?promoted={promoted}&q={term}&sort={sort}&type={addon_type}')
+    search_page = Search(selenium, base_url)
+    # verify if elements are correctly sorted by users
+    results = [getattr(result, sort) for result in search_page.result_list.extensions]
+    assert sorted(results, reverse=True) == results
+    # verify that no themes are showed
+    assert len(search_page.result_list.themes) == 0
+    # verify that only recommended add-ons are showed
+    results = search_page.result_list.extensions
+    for result in results:
+        assert promoted in result.promoted_badge_label.lower()
+
+    # search another term and run the same verifications
+    page.search.search_for(variables['search_term'])
+    results = [getattr(result, sort) for result in search_page.result_list.extensions]
+    assert sorted(results, reverse=True) == results
+    assert len(search_page.result_list.themes) == 0
+    results = search_page.result_list.extensions
+    for result in results:
+        assert promoted in result.promoted_badge_label.lower()
+
+
+@pytest.mark.nondestructive
+def test_filter_recommended_extensions_sort_by_users(base_url, selenium, variables):
+    page = Home(selenium, base_url).open()
+    search_page = page.search.search_for('')
+    sort = 'Most Users'
+    addon_type = 'Extension'
+    promoted = 'Recommended'
+    # apply filters and then search term
+    Select(search_page.filter_by_sort).select_by_visible_text(sort)
+    Select(search_page.filter_by_type).select_by_visible_text(addon_type)
+    Select(search_page.filter_by_badging).select_by_visible_text(promoted)
+    page.search.search_for(variables['search_term'])
+    # verify if elements are correctly sorted by users
+    results = [getattr(result, 'users') for result in search_page.result_list.extensions]
+    assert sorted(results, reverse=True) == results
+    # verify that no themes are showed
+    assert len(search_page.result_list.themes) == 0
+    # verify that only recommended add-ons are showed
+    results = search_page.result_list.extensions
+    for result in results:
+        assert promoted in result.promoted_badge_label
+
+
+@pytest.mark.nondestructive
 def test_filter_themes(base_url, selenium):
     page = Home(selenium, base_url).open()
     term = 'fox'

--- a/tests/frontend/test_search.py
+++ b/tests/frontend/test_search.py
@@ -285,35 +285,6 @@ def test_filter_extensions(base_url, selenium):
 @pytest.mark.nondestructive
 def test_filter_recommended_extensions_sort_by_users(base_url, selenium, variables):
     page = Home(selenium, base_url).open()
-    term = 'fox'
-    sort = 'users'
-    addon_type = 'extension'
-    promoted = 'recommended'
-    selenium.get(f'{base_url}/search/?promoted={promoted}&q={term}&sort={sort}&type={addon_type}')
-    search_page = Search(selenium, base_url)
-    # verify if elements are correctly sorted by users
-    results = [getattr(result, sort) for result in search_page.result_list.extensions]
-    assert sorted(results, reverse=True) == results
-    # verify that no themes are showed
-    assert len(search_page.result_list.themes) == 0
-    # verify that only recommended add-ons are showed
-    results = search_page.result_list.extensions
-    for result in results:
-        assert promoted in result.promoted_badge_label.lower()
-
-    # search another term and run the same verifications
-    page.search.search_for(variables['search_term'])
-    results = [getattr(result, sort) for result in search_page.result_list.extensions]
-    assert sorted(results, reverse=True) == results
-    assert len(search_page.result_list.themes) == 0
-    results = search_page.result_list.extensions
-    for result in results:
-        assert promoted in result.promoted_badge_label.lower()
-
-
-@pytest.mark.nondestructive
-def test_filter_recommended_extensions_sort_by_users(base_url, selenium, variables):
-    page = Home(selenium, base_url).open()
     search_page = page.search.search_for('')
     sort = 'Most Users'
     addon_type = 'Extension'


### PR DESCRIPTION
The purpose of these tests is to verify that combining filters when searching for add-ons works as expected.
Also, these tests verify that filters remain applied when searching for a new term.