### PR TITLE
Fix collection notes test

### DIFF
--- a/tests/frontend/test_collections.py
+++ b/tests/frontend/test_collections.py
@@ -194,6 +194,9 @@ def test_remove_addon_from_collection(selenium, base_url, variables, wait):
 
 
 @pytest.mark.serial
+@pytest.mark.skip(
+    reason='There is an error preventing notes to be deleted. Skipping until the issue is fixed'
+)
 @pytest.mark.nondestructive
 def test_collection_addon_notes(selenium, base_url, variables):
     collections = Collections(selenium, base_url).open().wait_for_page_to_load()

--- a/tests/frontend/test_collections.py
+++ b/tests/frontend/test_collections.py
@@ -191,12 +191,11 @@ def test_remove_addon_from_collection(selenium, base_url, variables, wait):
     )
     # checks that the addon we added at the beginning of the test was removed
     assert addon_name not in collections.create.edit_addons_list[0].edit_list_addon_name
-    
+
 
 @pytest.mark.skip(
     reason='There is an error preventing notes to be deleted. Skipping until the issue is fixed'
 )
-@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_collection_addon_notes(selenium, base_url, variables):
     collections = Collections(selenium, base_url).open().wait_for_page_to_load()

--- a/tests/frontend/test_collections.py
+++ b/tests/frontend/test_collections.py
@@ -296,42 +296,6 @@ def test_collection_edit_metadata(selenium, base_url, variables, wait):
 
 @pytest.mark.serial
 @pytest.mark.nondestructive
-def test_collection_addon_notes(selenium, base_url, variables):
-    collections = Collections(selenium, base_url).open().wait_for_page_to_load()
-    collections.login('collection_user')
-    collections.select_collection(0)
-    collections.collection_detail.click_edit_collection_button()
-    # writing a note for an addon in the collection list
-    collections.create.edit_addons_list[0].click_add_note()
-    collections.create.edit_addons_list[0].note_input_text(
-        variables['collection_addon_note']
-    )
-    collections.create.edit_addons_list[0].click_save_note()
-    # check that the note written is displayed after saving
-    assert (
-        variables['collection_addon_note']
-        in collections.create.edit_addons_list[0].note_text
-    )
-    # edit the collection addon note
-    collections.create.edit_addons_list[0].click_edit_note()
-    collections.create.edit_addons_list[0].note_input_text(
-        variables['collection_addon_edited_note']
-    )
-    collections.create.edit_addons_list[0].click_save_note()
-    # check that the edited note text is displayed after saving
-    assert (
-        variables['collection_addon_edited_note']
-        in collections.create.edit_addons_list[0].note_text
-    )
-    collections.create.edit_addons_list[0].click_edit_note()
-    # delete the collection note and check it is no longer displayed
-    collections.create.edit_addons_list[0].click_delete_note()
-    with pytest.raises(NoSuchElementException):
-        selenium.find_element(By.CSS_SELECTOR, '.EditableCollectionAddon-notes-content')
-
-
-@pytest.mark.serial
-@pytest.mark.nondestructive
 def test_add_to_collection_in_addon_detail_page(selenium, base_url, variables, wait):
     collections = Collections(selenium, base_url).open().wait_for_page_to_load()
     collections.login('collection_user')

--- a/tests/frontend/test_collections.py
+++ b/tests/frontend/test_collections.py
@@ -191,12 +191,12 @@ def test_remove_addon_from_collection(selenium, base_url, variables, wait):
     )
     # checks that the addon we added at the beginning of the test was removed
     assert addon_name not in collections.create.edit_addons_list[0].edit_list_addon_name
+    
 
-
-@pytest.mark.serial
 @pytest.mark.skip(
     reason='There is an error preventing notes to be deleted. Skipping until the issue is fixed'
 )
+@pytest.mark.serial
 @pytest.mark.nondestructive
 def test_collection_addon_notes(selenium, base_url, variables):
     collections = Collections(selenium, base_url).open().wait_for_page_to_load()


### PR DESCRIPTION
Skipping the collection notes test until a bug in AMO is fixed.

Also, this test was added twice in the collections tests script (by accident most likely), so I've deleted one of the occurrences. 