### PR TITLE
Remove check for site status footer link

### DIFF
--- a/tests/frontend/test_home.py
+++ b/tests/frontend/test_home.py
@@ -251,7 +251,6 @@ def test_mozilla_footer_link(base_url, selenium):
             'discourse',
             'Contact_us',
             'review_guide',
-            'mozilla.org',  # temporary
         ]
     ),
 )


### PR DESCRIPTION
A small change that removes the check for the footer site status in `test_addons_footer_links`. This link  has been removed from AMO frontend - https://github.com/mozilla/addons-frontend/issues/11308