### PR TITLE
Add tests for install and links in the blog addon cards

### DIFF
--- a/pages/desktop/frontend/blog.py
+++ b/pages/desktop/frontend/blog.py
@@ -1,4 +1,5 @@
 from pypom import Region
+
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -48,7 +49,7 @@ class BlogHomepage(Base):
 
         def click_read_more_link(self):
             self.read_more_link.click()
-            return ArticlePage(self.driver, self.page.base_url)
+            return ArticlePage(self.driver, self.page.base_url).wait_for_page_to_load()
 
 
 class ArticlePage(Base):


### PR DESCRIPTION
Add three tests for the blog page to be run during sanity testing (stage is not covered yet because the blog doesn't have a dedicated infrastructure that supports installations):
- add-on installation from the blog
- checking that add-on links go to AMO addon details page
- checking that author links go to AMO user profile page