### PR TITLE
Add sanity tests for about:addons page

### DIFF
--- a/pages/desktop/frontend/details.py
+++ b/pages/desktop/frontend/details.py
@@ -200,6 +200,10 @@ class Detail(Base):
         _stats_users_locator = (By.CSS_SELECTOR, '.AddonMeta dl:nth-child(1)')
         _stats_reviews_locator = (By.CSS_SELECTOR, '.AddonMeta dl:nth-child(2)')
         _stats_ratings_locator = (By.CSS_SELECTOR, '.AddonMeta dl:nth-child(3)')
+        _rating_score_title_locator = (
+            By.CSS_SELECTOR,
+            '.AddonMeta-rating-content .Rating--small',
+        )
         _grouped_ratings_locator = (By.CSS_SELECTOR, '.RatingsByStar-star')
         _rating_bar_locator = (By.CSS_SELECTOR, '.RatingsByStar-barContainer')
         _rating_bar_count_locator = (By.CSS_SELECTOR, '.RatingsByStar-count')
@@ -237,6 +241,12 @@ class Detail(Base):
         @property
         def addon_star_rating_stats(self):
             return self.find_element(*self._stats_ratings_locator)
+
+        @property
+        def rating_score_tile(self):
+            return self.find_element(*self._rating_score_title_locator).get_attribute(
+                'title'
+            )
 
         @property
         def no_star_ratings(self):

--- a/pages/desktop/frontend/search.py
+++ b/pages/desktop/frontend/search.py
@@ -38,7 +38,7 @@ class Search(Page):
         """method used when we need to check that the search results list
         contains a certain number of items"""
         self.wait.until(
-            lambda _: len(self.result_list.extensions) > count,
+            lambda _: len(self.result_list.extensions) >= count,
             message=f'Expected search results to be {count} but the list returned {len(self.result_list.extensions)}',
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,11 @@ def firefox_options(firefox_options, request):
     if marker:
         firefox_options.add_argument('-headless')
         firefox_options.log.level = 'trace'
+        firefox_options.set_preference(
+            'extensions.getAddons.discovery.api_url',
+            'https://services.addons.mozilla.org/api/v4/discovery/?lang=%LOCALE%&edition=%DISTRIBUTION%',
+        )
+        firefox_options.set_preference('extensions.getAddons.cache.enabled', True)
     else:
         firefox_options.set_preference('extensions.install.requireBuiltInCerts', False)
         firefox_options.set_preference('xpinstall.signatures.required', False)
@@ -77,7 +82,9 @@ def selenium(selenium, request):
 def wait():
     """A preset wait to be used in test methods. Removes the necessity to declare a
     WebDriverWait whenever we need to wait for certain conditions to happen in a test"""
-    return WebDriverWait(selenium, 10, ignored_exceptions=StaleElementReferenceException)
+    return WebDriverWait(
+        selenium, 10, ignored_exceptions=StaleElementReferenceException
+    )
 
 
 @pytest.fixture

--- a/tests/frontend/test_sanity.py
+++ b/tests/frontend/test_sanity.py
@@ -116,12 +116,12 @@ def test_about_addons_search(selenium, base_url):
 
 @pytest.mark.prod_only
 @pytest.mark.firefox_release
-def test_about_addons_find_more_addons(selenium, base_url):
+def test_about_addons_find_more_addons(selenium, base_url, wait):
     selenium.get('about:addons')
     about_addons = AboutAddons(selenium).wait_for_page_to_load()
     amo_home = about_addons.click_find_more_addons()
     # checks that the button redirects correctly to AMO homepage
-    assert amo_home.primary_hero.is_displayed()
+    wait.until(lambda _: amo_home.primary_hero.is_displayed())
 
 
 @pytest.mark.prod_only

--- a/tests/frontend/test_sanity.py
+++ b/tests/frontend/test_sanity.py
@@ -1,6 +1,7 @@
 import pytest
 import random
 
+from pages.desktop.about_addons import AboutAddons
 from pages.desktop.frontend.details import Detail
 from pages.desktop.frontend.language_tools import LanguageTools
 
@@ -97,3 +98,148 @@ def test_install_theme(selenium, base_url, variables, firefox, firefox_notificat
     # uninstall the theme and check that install button changes state
     addon.install()
     assert 'Install Theme' in addon.button_text
+
+
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_about_addons_search(selenium, base_url):
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium).wait_for_page_to_load()
+    amo_search_results = about_addons.search_box('privacy')
+    # verify that the query string is registered in AMO search results page title
+    amo_search_results.wait_for_contextcard_update('privacy')
+    # verify that the search query produced results (this is a popular query so we expect
+    # to see the first page of results to be fully populated, i.e. 25 items)
+    amo_search_results.search_results_list_loaded(25)
+    assert 'privacy' in amo_search_results.result_list.extensions[0].name.lower()
+
+
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_about_addons_find_more_addons(selenium, base_url):
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium).wait_for_page_to_load()
+    amo_home = about_addons.click_find_more_addons()
+    # checks that the button redirects correctly to AMO homepage
+    assert amo_home.primary_hero.is_displayed()
+
+
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_about_addons_addon_cards(selenium, base_url, wait):
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium)
+    # waits for the list of addon cards to be loaded
+    wait.until(
+        lambda _: len([el.disco_addon_name for el in about_addons.addon_cards_items])
+        >= 8
+    )
+    # theme images are slower to load, so we need to wait for them to be visible too
+    wait.until(lambda _: about_addons.addon_cards_items[0].theme_image.is_displayed())
+    for item in about_addons.addon_cards_items:
+        # extension cards should have the following elements
+        if item.is_extension_card():
+            assert item.disco_addon_name.is_displayed()
+            assert item.disco_addon_author.is_displayed()
+            assert len(item.disco_extension_summary) > 0
+            assert item.disco_extension_rating.is_displayed()
+            assert item.disco_extension_users.is_displayed()
+            assert item.extension_image.is_displayed()
+        else:
+            # theme cards should have only these items
+            assert item.disco_addon_name.is_displayed()
+            assert item.disco_addon_author.is_displayed()
+            assert item.theme_image.is_displayed()
+
+
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_about_addons_addon_cards_author_link(selenium, base_url, wait):
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium)
+    # waiting for the addon cards data to be retrieved (the author names in this case)
+    wait.until(
+        lambda _: len([el.disco_addon_author for el in about_addons.addon_cards_items])
+        >= 8
+    )
+    disco_addon_name = about_addons.addon_cards_items[0].disco_addon_name.text
+    # clicking on the author link should open the addon detail page on AMO
+    amo_detail_page = about_addons.addon_cards_items[0].click_disco_addon_author()
+    # checking that the expected detail page was opened
+    wait.until(lambda _: disco_addon_name == amo_detail_page.name)
+
+
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_about_addons_addon_stats_match_amo(selenium, base_url, wait):
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium)
+    # waiting for the addon cards data to be retrieved (the author names in this case)
+    wait.until(
+        lambda _: len([el.disco_addon_author for el in about_addons.addon_cards_items])
+        >= 8
+    )
+    disco_addon_name = about_addons.addon_cards_items[1].disco_addon_name.text
+    disco_rating_score = about_addons.addon_cards_items[1].rating_score
+    disco_users = about_addons.addon_cards_items[1].user_count
+    # clicking on the author link should open the addon detail page on AMO
+    amo_detail_page = about_addons.addon_cards_items[1].click_disco_addon_author()
+    wait.until(lambda _: disco_addon_name == amo_detail_page.name)
+    # check that the rating and the users from about:addons are matching with AMO
+    assert disco_rating_score == amo_detail_page.stats.rating_score_tile
+    assert disco_users == amo_detail_page.stats.stats_users_count
+
+
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_about_addons_install_extension(
+    selenium, base_url, wait, firefox, firefox_notifications
+):
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium)
+    # waiting for the addon cards data to be retrieved (the install buttons in this case)
+    wait.until(
+        lambda _: len([el.install_button for el in about_addons.addon_cards_items]) >= 8
+    )
+    disco_addon_name = about_addons.addon_cards_items[1].disco_addon_name.text
+    # install the recommended extension
+    about_addons.addon_cards_items[1].install_button.click()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    # some addons will open support pages in new tabs after installation;
+    # we need to return to the first (about:addons) tab if that happens
+    if len(selenium.window_handles) > 1:
+        selenium.switch_to.window(selenium.window_handles[0])
+    # open the manage Extensions page to verify that the addon was installed correctly
+    about_addons.click_extensions_side_button()
+    # verify that the extension installed is present in manage Extensions
+    assert disco_addon_name in [el.text for el in about_addons.installed_addon_name]
+
+
+@pytest.mark.prod_only
+@pytest.mark.firefox_release
+def test_about_addons_install_theme(
+    selenium, base_url, wait, firefox, firefox_notifications
+):
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium)
+    # waiting for the addon cards data to be retrieved (the install buttons in this case)
+    wait.until(
+        lambda _: len([el.install_button for el in about_addons.addon_cards_items]) >= 8
+    )
+    disco_theme_name = about_addons.addon_cards_items[0].disco_addon_name.text
+    # make a note of the image source of the theme we are about to install
+    disco_theme_image = about_addons.addon_cards_items[0].theme_image.get_attribute(
+        'src'
+    )
+    # install the recommended theme
+    about_addons.addon_cards_items[0].install_button.click()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    about_addons.click_themes_side_button()
+    # check that installed theme should be first on the manage Themes page
+    assert disco_theme_name in about_addons.installed_addon_name[0].text
+    assert 'true' in about_addons.enabled_theme_active_status
+    assert disco_theme_image == about_addons.enabled_theme_image


### PR DESCRIPTION
Included in this PR:

- page objects for the recommendations pane in about:addons
- tests covering the recommendations pane in about:addons 
- some tweaking to firefox capabilities to make sure about:addons is populated with data 

These tests will be run during the sanity run.