### PR TITLE
Setup for session cookie authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,40 @@ jobs:
       - store_artifacts:
           path: devhub-parallel-test-results.html
 
+  # tests covering addon submissions through DevHub
+  addon_submissions_tests:
+    executor:
+      name: win/default
+      version: "previous"
+      size: "medium"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Install python 3.9
+          command: choco install python --version=3.9.0
+      - run:
+          name: Upgrade pip
+          command: pip install --upgrade pip --user
+      - run:
+          name: Install requirements
+          command: pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox-nightly --pre
+      - run:
+          name: Run addon submissions tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 1 --reruns 2
+          command: pytest tests\devhub\test_addon_submissions.py --driver Firefox --variables stage.json --html=submissions-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: submissions-test-results.html
+
   # parallel tests run on production after the AMO push
   sanity_parallel_tests:
     executor:
@@ -254,6 +288,7 @@ workflows:
       - user_serial_tests
       - frontend_parallel_tests
       - devhub_parallel_tests
+      - addon_submissions_tests
   # scheduled in CircleCI Project settings to run each Wednesdays at 05:00 UTC
   scheduled_stage_release_run:
     when:
@@ -266,6 +301,7 @@ workflows:
       - user_serial_tests
       - frontend_parallel_tests
       - devhub_parallel_tests
+      - addon_submissions_tests
   # scheduled in CircleCI Project settings to start each Thursdays at 17:00 UTC
   scheduled_prod_sanity_run:
     when:

--- a/pages/desktop/frontend/login.py
+++ b/pages/desktop/frontend/login.py
@@ -141,3 +141,22 @@ class Login(Base):
                 requests.get(f'https://restmail.net/mail/{mail}', timeout=10)
                 print('Restmail did not receive an email from FxA')
         return self
+
+    def get_session_cookie(self, user):
+        """A method that reads the sessionid cookie generated after a successful login"""
+        page = Base(self.selenium, self.base_url)
+        page.header.click_login()
+        self.wait.until(
+            EC.visibility_of_element_located((By.NAME, 'email')),
+            message=f'FxA email input field was not displayed in {self.selenium.current_url}',
+        )
+        self.account(user)
+        self.wait.until(
+            EC.url_contains('addons'),
+            message=f'AMO could not be loaded in {self.selenium.current_url}',
+        )
+        session_cookie = self.selenium.get_cookie('sessionid')
+        # store cookie in a dynamic file created only at runtime based on a specific user;
+        # this file is destroyed (via a fixture) once the tests that needed it were run
+        with open(f'{user}.txt', 'w') as file:
+            file.write(session_cookie['value'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,41 @@ def wait():
 
 
 @pytest.fixture
+def set_session_cookie(selenium, base_url, request):
+    """Fixture used when we want to open an AMO page with a sessionid
+    cookie (i.e. a logged-in user) already set"""
+    # the user file is passed in the test as a marker argument
+    marker = request.node.get_closest_marker('user_data')
+    user_file = marker.args[0]
+    with open(f'{user_file}.txt', 'r') as file:
+        cookie_value = str(file.read())
+    # need to set the url context if we want to apply a cookie
+    # in order to avoid InvalidCookieDomainException error
+    selenium.get(base_url)
+    # set the sessionid cookie
+    create_session = selenium.add_cookie(
+        {
+            "name": "sessionid",
+            "value": cookie_value,
+        }
+    )
+    return create_session
+
+
+@pytest.fixture
+def destroy_file(request):
+    """Fixture to delete user files created for a test suite"""
+    marker = request.node.get_closest_marker('user_data')
+    user_file = marker.args[0]
+    import os
+
+    if os.path.exists(f'{user_file}.txt'):
+        os.remove(f'{user_file}.txt')
+    else:
+        print("The file does not exist")
+
+
+@pytest.fixture
 def fxa_account(request):
     """Fxa account to use during tests that need to login.
 

--- a/tests/devhub/test_addon_submissions.py
+++ b/tests/devhub/test_addon_submissions.py
@@ -1,0 +1,36 @@
+import pytest
+
+from pages.desktop.frontend.home import Home
+from pages.desktop.frontend.login import Login
+
+
+@pytest.mark.sanity
+@pytest.mark.serial
+def test_create_submissions_user_session(selenium, base_url):
+    """Create a user session to be used in subsequent tests"""
+    Home(selenium, base_url).open().wait_for_page_to_load()
+    login = Login(selenium, base_url)
+    login.get_session_cookie('submissions_user')
+
+
+# TODO: tests covering addon submissions will be added here
+
+
+# These last parts handle the session cookie invalidation and user file deletion
+@pytest.mark.sanity
+@pytest.mark.serial
+@pytest.mark.user_data('submissions_user')
+def test_clear_submission_session(base_url, selenium, set_session_cookie):
+    """Logout to invalidate session cookie"""
+    page = Home(selenium, base_url).open().wait_for_page_to_load()
+    page.logout()
+
+
+@pytest.mark.sanity
+@pytest.mark.serial
+@pytest.mark.user_data('submissions_user')
+def test_destroy_file(destroy_file):
+    """Destroy user session file and verify that it was deleted"""
+    with pytest.raises(FileNotFoundError):
+        with open('submissions_user.txt', 'r') as file:
+            file.read()


### PR DESCRIPTION
What is covered in this PR:
- add fixtures for setting and deleting session cookies
- update CircleCI config to run addon submission tests
- add method that reads the session cookie
- create the test file that will store the submission tests and test the initial setup (i.e. setting and deleting session cookies)