### PR TITLE
Coverage test devhub home

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -402,6 +402,9 @@ class Footer(Region):
     _footer_links_locator = (By.CSS_SELECTOR, '.Footer-links li a')
     _footer_legal_locator = (By.CSS_SELECTOR, '.Footer-legal-links ')
     _language_picker_locator = (By.ID, 'lang-picker')
+    _copyright_message_locator = (By.CSS_SELECTOR, '.Footer-copyright')
+    _noted_link_locator = (By.CSS_SELECTOR, '.Footer-copyright > a:nth-child(1)')
+    _license_link_locator = (By.CSS_SELECTOR, '.Footer-copyright > a:nth-child(2)')
 
     @property
     def addon_links(self):
@@ -435,3 +438,15 @@ class Footer(Region):
     def language_picker(self, value):
         select = Select(self.find_element(*self._language_picker_locator))
         select.select_by_visible_text(value)
+
+    @property
+    def copyright_message(self):
+        return self.find_element(*self._copyright_message_locator)
+
+    @property
+    def noted_link(self):
+        return self.find_element(*self._noted_link_locator)
+
+    @property
+    def license_link(self):
+        return self.find_element(*self._license_link_locator)

--- a/pages/desktop/developers/devhub_home.py
+++ b/pages/desktop/developers/devhub_home.py
@@ -89,6 +89,7 @@ class DevHubHome(Base):
         '.DevHub-callout-box--banner a',
     )
     _my_addons_section_header_locator = (By.CSS_SELECTOR, '.DevHub-MyAddons h2')
+    _my_addons_section_paragraph_locator = (By.CSS_SELECTOR, '.DevHub-MyAddons-copy')
     _my_addons_section_list_locator = (By.CSS_SELECTOR, '.DevHub-MyAddons-item')
     _see_all_addons_link_locator = (
         By.CSS_SELECTOR,
@@ -96,11 +97,11 @@ class DevHubHome(Base):
     )
     _submit_addon_button_locator = (
         By.CSS_SELECTOR,
-        '.DevHub-MyAddons-item-buttons-submit a:nth-child(1)',
+        '.DevHub-MyAddons .Button:nth-of-type(1)',
     )
     _submit_theme_button_locator = (
         By.CSS_SELECTOR,
-        '.DevHub-MyAddons-item-buttons-submit a:nth-child(2)',
+        '.DevHub-MyAddons .Button:nth-of-type(2)',
     )
 
     def wait_for_page_to_load(self):
@@ -245,6 +246,14 @@ class DevHubHome(Base):
     @property
     def logged_in_hero_banner_header(self):
         return self.find_element(*self._logged_in_hero_banner_header_locator).text
+
+    @property
+    def my_addons_section_header(self):
+        return self.find_element(*self._my_addons_section_header_locator)
+
+    @property
+    def my_addons_section_paragraph(self):
+        return self.find_element(*self._my_addons_section_paragraph_locator)
 
     @property
     def logged_in_hero_banner_text(self):

--- a/pages/desktop/developers/submit_addon.py
+++ b/pages/desktop/developers/submit_addon.py
@@ -7,6 +7,10 @@ class SubmitAddon(Base):
 
     _my_addons_page_logo_locator = (By.CSS_SELECTOR, '.site-titles')
     _submission_form_header_locator = (By.CSS_SELECTOR, '.is_addon')
+    _addon_distribution_header_locator = (
+        By.CSS_SELECTOR,
+        '.addon-submission-process h3',
+    )
 
     @property
     def my_addons_page_logo(self):
@@ -15,3 +19,7 @@ class SubmitAddon(Base):
     @property
     def submission_form_header(self):
         return self.find_element(*self._submission_form_header_locator)
+
+    @property
+    def distribution_header(self):
+        return self.find_element(*self._addon_distribution_header_locator)

--- a/stage.json
+++ b/stage.json
@@ -84,6 +84,7 @@
 
   "devhub_overview_header": "Customize Firefox",
   "devhub_overview_summary": "Whether you’re new to extension development, polishing up or porting an existing extension or theme, or creating a custom enterprise solution, we’ve got the resources to support you.",
+  "devhub_my_addons_section_paragraph": "This is where you view and manage your add-ons and themes. To publish your first add-on, click \"Submit Your First Add-on\" or \"Submit Your First Theme\".",
   "devhub_content_header": "Ready to submit or manage your extension?",
   "devhub_content_summary": "Sign in to the Developer Hub to submit or manage extensions and themes",
   "devhub_get_involved_header": "Get involved",
@@ -111,5 +112,7 @@
   ],
   "devhub_resources_review_addons_text": "Volunteer reviewers help keep add-ons safe and reliable to use. They enjoy great perks too!",
   "devhub_resources_write_some_code_text": "Help make add-ons better by contributing your coding skills.",
-  "devhub_resources_participate_text": "You don't need coding skills to help keep Firefox the most customizable browser available!"
+  "devhub_resources_participate_text": "You don't need coding skills to help keep Firefox the most customizable browser available!",
+  "devhub_submit_addon_agreement_header": "Add-on Distribution Agreement",
+  "devhub_submit_addon_distribution_header": "How to Distribute this Version"
 }

--- a/tests/devhub/test_devhub_home.py
+++ b/tests/devhub/test_devhub_home.py
@@ -145,6 +145,19 @@ def test_devhub_logged_in_page_hero_banner(selenium, base_url, variables):
 
 
 @pytest.mark.nondestructive
+def test_devhub_my_addons_section(selenium, base_url, variables):
+    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    page.devhub_login('regular_user')
+    page.wait_for_page_to_load()
+    assert 'My Add-ons' in page.my_addons_section_header.text
+    # if the current account has no add-ons submitted, this paragraph will be displayed
+    assert (
+        variables['devhub_my_addons_section_paragraph']
+        in page.my_addons_section_paragraph.text
+    )
+
+
+@pytest.mark.nondestructive
 def test_devhub_my_addons_list_items(selenium, base_url, wait):
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     page.devhub_login('developer')
@@ -209,6 +222,46 @@ def test_devhub_click_submit_new_theme_button(selenium, base_url, wait):
         lambda _: distribution_page.submission_form_header.is_displayed(),
         message='The addon distribution page header as not displayed',
     )
+
+
+@pytest.mark.nondestructive
+def test_devhub_click_first_addon_button(selenium, base_url, variables):
+    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    # an account with no add-ons submitted is used
+    page.devhub_login('regular_user')
+    page.wait_for_page_to_load()
+    distribution_page = page.click_submit_addon_button()
+    # if this user never accepted the distribution agreement, it should be displayed in the page, otherwise not
+    try:
+        assert (
+            variables['devhub_submit_addon_agreement_header']
+            in distribution_page.distribution_header.text
+        )
+    except AssertionError:
+        assert (
+            variables['devhub_submit_addon_distribution_header']
+            in distribution_page.distribution_header.text
+        )
+
+
+@pytest.mark.nondestructive
+def test_devhub_click_first_theme_button(selenium, base_url, variables):
+    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    # an account with no add-ons submitted is used
+    page.devhub_login('regular_user')
+    page.wait_for_page_to_load()
+    distribution_page = page.click_submit_theme_button()
+    # if this user never accepted the distribution agreement, it should be displayed in the page, otherwise not
+    try:
+        assert (
+            variables['devhub_submit_addon_agreement_header']
+            in distribution_page.distribution_header.text
+        )
+    except AssertionError:
+        assert (
+            variables['devhub_submit_addon_distribution_header']
+            in distribution_page.distribution_header.text
+        )
 
 
 @pytest.mark.nondestructive
@@ -534,3 +587,15 @@ def test_change_devhub_language(base_url, selenium, language, locale, translatio
     page.footer_language_picker(language)
     assert f'{locale}/developers/' in selenium.current_url
     assert translation in page.page_logo.text
+
+
+@pytest.mark.nondestructive
+def test_devhub_footer_copyright_message(base_url, selenium):
+    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    assert page.footer.copyright_message.is_displayed()
+    page.footer.noted_link.click()
+    assert '/about/legal' in selenium.current_url
+    page.driver.back()
+    page.wait_for_page_to_load()
+    page.footer.license_link.click()
+    assert 'creativecommons.org/licenses' in selenium.current_url


### PR DESCRIPTION
Added tests for devhub home page:
-test that verifies my add-ons paragraph (only displayed when user has no submitted add-ons)
-tests that verifies 'Submit Your First Add-on' and 'Submit Your First Theme' buttons (displayed the same as above)
-test for license message from page footer