### PR TITLE
Improve footer tests

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -387,10 +387,9 @@ class Footer(Region):
     _footer_social_locator = (By.CSS_SELECTOR, '.Footer-links-social')
     _footer_links_locator = (By.CSS_SELECTOR, '.Footer-links li a')
     _footer_legal_locator = (By.CSS_SELECTOR, '.Footer-legal-links ')
-    _language_picker_locator = (By.ID, 'lang-picker')
+    _footer_copyright_links_locator = (By.CSS_SELECTOR, '.Footer-copyright a')
     _copyright_message_locator = (By.CSS_SELECTOR, '.Footer-copyright')
-    _noted_link_locator = (By.CSS_SELECTOR, '.Footer-copyright > a:nth-child(1)')
-    _license_link_locator = (By.CSS_SELECTOR, '.Footer-copyright > a:nth-child(2)')
+    _language_picker_locator = (By.ID, 'lang-picker')
 
     @property
     def addon_links(self):
@@ -421,18 +420,14 @@ class Footer(Region):
         element = self.find_element(*self._footer_legal_locator)
         return element.find_elements(By.CSS_SELECTOR, 'li a')
 
-    def language_picker(self, value):
-        select = Select(self.find_element(*self._language_picker_locator))
-        select.select_by_visible_text(value)
+    @property
+    def copyright_links(self):
+        return self.find_elements(*self._footer_copyright_links_locator)
 
     @property
     def copyright_message(self):
         return self.find_element(*self._copyright_message_locator)
 
-    @property
-    def noted_link(self):
-        return self.find_element(*self._noted_link_locator)
-
-    @property
-    def license_link(self):
-        return self.find_element(*self._license_link_locator)
+    def language_picker(self, value):
+        select = Select(self.find_element(*self._language_picker_locator))
+        select.select_by_visible_text(value)

--- a/tests/devhub/test_devhub_home.py
+++ b/tests/devhub/test_devhub_home.py
@@ -1,5 +1,6 @@
 import pytest
 
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 
 from pages.desktop.developers.devhub_home import DevHubHome
@@ -589,13 +590,26 @@ def test_change_devhub_language(base_url, selenium, language, locale, translatio
     assert translation in page.page_logo.text
 
 
+@pytest.mark.parametrize(
+    'count, link',
+    enumerate(
+        [
+            ['/about/legal/', '.mzp-c-article-title'],
+            ['/licenses/by-sa/3.0/', '.cc-license-title'],
+        ]
+    ),
+    ids=[
+        'Legal',
+        'Creative Commons License',
+    ],
+)
 @pytest.mark.nondestructive
-def test_devhub_footer_copyright_message(base_url, selenium):
+def test_devhub_footer_copyright_message(base_url, selenium, count, link):
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     assert page.footer.copyright_message.is_displayed()
-    page.footer.noted_link.click()
-    assert '/about/legal' in selenium.current_url
-    page.driver.back()
-    page.wait_for_page_to_load()
-    page.footer.license_link.click()
-    assert 'creativecommons.org/licenses' in selenium.current_url
+    page.footer.copyright_links[count].click()
+    page.wait_for_current_url(link[0])
+    page.wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
+        message=f'The chosen element "{link[1]}" could not be loaded on the "{link[0]}" webpage',
+    )

--- a/tests/frontend/test_home.py
+++ b/tests/frontend/test_home.py
@@ -1,6 +1,8 @@
 import pytest
 
 from selenium.webdriver import ActionChains
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 
 from pages.desktop.frontend.home import Home
 from pages.desktop.frontend.search import Search
@@ -260,73 +262,115 @@ def test_mozilla_footer_link(base_url, selenium):
     page = Home(selenium, base_url).open().wait_for_page_to_load()
     page.footer.mozilla_link.click()
     assert 'mozilla.org' in selenium.current_url
+    page.wait.until(
+        EC.visibility_of_element_located(
+            (By.CSS_SELECTOR, '.fx100-hero-cta-container .mzp-c-button')
+        ),
+        message='The chosen element could not be loaded on the Mozilla webpage',
+    )
 
 
 @pytest.mark.parametrize(
     'count, link',
     enumerate(
         [
-            'about',
-            'blog',
-            'extensionworkshop',
-            'developers',
-            'add-on-policies',
-            'blog.mozilla.org',
-            'discourse',
-            'Contact_us',
-            'review_guide',
+            ['about', '#about'],
+            ['blog', '.blog-entries'],
+            ['extensionworkshop', '.grid-container h1'],
+            ['developers', '.DevHub-Navigation-Logo'],
+            ['add-on-policies', '.page-hero-description h1'],
+            ['blog.mozilla.org', '.featured-posts'],
+            ['discourse', '.category-list'],
+            ['Contact_us', '.main-page-content'],
+            ['review_guide', '#review-guide'],
         ]
     ),
+    ids=[
+        'About',
+        'Firefox Add-ons Blog',
+        'Extension Workshop',
+        'Developer Hub',
+        'Developer Policies',
+        'Community Blog',
+        'Forum',
+        'Report a bug',
+        'Review Guide',
+    ],
 )
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_addons_footer_links(base_url, selenium, count, link):
     page = Home(selenium, base_url).open().wait_for_page_to_load()
     page.footer.addon_links[count].click()
-    page.wait_for_current_url(link)
+    page.wait_for_current_url(link[0])
+    page.wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
+        message=f'The chosen element "{link[1]}" could not be loaded on the "{link[0]}" webpage',
+    )
 
 
 @pytest.mark.parametrize(
-    'count, links',
+    'count, link',
     enumerate(
         [
-            'firefox/new',
-            'firefox/browsers/mobile/',
-            'mixedreality.mozilla.org',
-            'firefox/enterprise/',
+            ['firefox/new', '#download-button-thanks'],
+            ['firefox/browsers/mobile/', '#android-download'],
+            ['mixedreality.mozilla.org', '.featured__logo'],
+            ['firefox/enterprise/', '#primary-download-button'],
         ]
     ),
+    ids=[
+        'Firefox Desktop',
+        'Firefox Mobile',
+        'Firefox Reality',
+        'Firefox Enterprise',
+    ],
 )
 @pytest.mark.nondestructive
 @pytest.mark.sanity
-def test_browsers_footer_links(base_url, selenium, count, links):
+def test_browsers_footer_links(base_url, selenium, count, link):
     page = Home(selenium, base_url).open().wait_for_page_to_load()
     page.footer.browsers_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link[0])
+    page.wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
+        message=f'The chosen element "{link[1]}" could not be loaded on the "{link[0]}" webpage',
+    )
 
 
 @pytest.mark.parametrize(
-    'count, links',
+    'count, link',
     enumerate(
         [
-            'firefox/browsers/',
-            'products/vpn/',
-            'relay.firefox.com/',
-            'monitor.firefox',
-            'getpocket.com',
+            ['firefox/browsers/', '.mzp-c-split-body h1'],
+            ['products/vpn/', '.vpn-hero-heading'],
+            ['relay.firefox.com/', '.Button_button__oJAQ2'],
+            ['monitor.firefox', '.fx-monitor-logotype'],
+            ['getpocket.com', '.mzp-t-product-pocket'],
         ]
     ),
+    ids=[
+        'Browsers',
+        'VPN',
+        'Relay',
+        'Monitor',
+        'Pocket',
+    ],
 )
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-def test_products_footer_links(base_url, selenium, count, links):
+def test_products_footer_links(base_url, selenium, count, link):
     page = Home(selenium, base_url).open().wait_for_page_to_load()
     page.footer.products_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link[0])
+    page.wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
+        message=f'The chosen element "{link[1]}" could not be loaded on the "{link[0]}" webpage',
+    )
 
 
 @pytest.mark.parametrize(
-    'count, links',
+    'count, link',
     enumerate(
         [
             'twitter.com',
@@ -334,31 +378,71 @@ def test_products_footer_links(base_url, selenium, count, links):
             'youtube.com',
         ]
     ),
+    ids=[
+        'Firefox on Twitter',
+        'Firefox on Instagram',
+        'Firefox on YouTube',
+    ],
 )
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-def test_social_footer_links(base_url, selenium, count, links):
+def test_social_footer_links(base_url, selenium, count, link):
     page = Home(selenium, base_url).open().wait_for_page_to_load()
     page.footer.social_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link)
 
 
 @pytest.mark.parametrize(
-    'count, links',
+    'count, link',
     enumerate(
         [
-            'privacy/websites/',
-            'privacy/websites/',
-            'legal/terms/mozilla',
+            ['privacy/websites/', '.privacy-title'],
+            ['privacy/websites/', '.privacy-title'],
+            ['legal/terms/mozilla', '#websites-communications-terms-of-use'],
         ]
     ),
+    ids=[
+        'Privacy',
+        'Cookies',
+        'Legal',
+    ],
 )
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-def test_legal_footer_links(base_url, selenium, count, links):
+def test_legal_footer_links(base_url, selenium, count, link):
     page = Home(selenium, base_url).open().wait_for_page_to_load()
     page.footer.legal_links[count].click()
-    page.wait_for_current_url(links)
+    page.wait_for_current_url(link[0])
+    page.wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
+        message=f'The chosen element "{link[1]}" could not be loaded on the "{link[0]}" webpage',
+    )
+
+
+@pytest.mark.parametrize(
+    'count, link',
+    enumerate(
+        [
+            ['/about/legal/', '.mzp-c-article-title'],
+            ['/licenses/by-sa/3.0/', '.cc-license-title'],
+        ]
+    ),
+    ids=[
+        'Legal',
+        'Creative Commons License',
+    ],
+)
+@pytest.mark.sanity
+@pytest.mark.nondestructive
+def test_copyright_footer_links(base_url, selenium, count, link):
+    page = Home(selenium, base_url).open().wait_for_page_to_load()
+    assert page.footer.copyright_message.is_displayed()
+    page.footer.copyright_links[count].click()
+    page.wait_for_current_url(link[0])
+    page.wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
+        message=f'The chosen element "{link[1]}" could not be loaded on the "{link[0]}" webpage',
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add some improvements to the homepage footer tests:
 - add additional page checks
 - add wait messages 
 - add missing test for the copyright message and links
 - update copyright message and links test in the devhub suite