### PR TITLE
Tests for creating/editing addons with invalid payloads

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -1,3 +1,4 @@
 {
-   "base_url": "https://addons-dev.allizom.org"
+   "base_url": "https://addons-dev.allizom.org",
+   "approved_addon_with_sources": "approved-src-code"
 }


### PR DESCRIPTION
Included in this PR:
- submitting addons with invalid android or firefox categories
- submitting addons with invalid slugs
- setting invalid add-on names
- setting an invalid summary