### PR TITLE
Tests for editing addons with invalid payloads - part two

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -1,4 +1,5 @@
 {
    "base_url": "https://addons-dev.allizom.org",
-   "approved_addon_with_sources": "approved-src-code"
+   "approved_addon_with_sources": "approved-src-code",
+   "contributions_bad_request_message": "{\"contributions_url\":[\"URL domain must be one of [www.buymeacoffee.com, donate.mozilla.org, flattr.com, github.com, ko-fi.com, liberapay.com, www.micropayment.de, opencollective.com, www.patreon.com, www.paypal.com, paypal.me].\"]}"
 }


### PR DESCRIPTION
This PR includes:
- a test for editing addon names with a trademark name (Mozilla/Firefox)
- test for invalid addon homepage values
- test for addon invalid email domains
- test for invalid `experimental` and `requires payment` fields
- test for valid/invalid contribution domains
- test for invalid addon tags 

Edit: failing test is unrelated; caused by a basket email service disruption 