### PR TITLE
Remove Reality link from Devhub footer test

### DIFF
--- a/tests/devhub/test_devhub_home.py
+++ b/tests/devhub/test_devhub_home.py
@@ -477,14 +477,12 @@ def test_devhub_addons_footer_links(base_url, selenium, count, link):
         [
             'firefox/new',
             'firefox/browsers/mobile/',
-            'mixedreality.mozilla.org',
             'firefox/enterprise/',
         ]
     ),
     ids=[
         'DevHub Footer - Browsers section -  Desktop',
         'DevHub Footer - Browsers section -  Mobile',
-        'DevHub Footer - Browsers section -  Reality',
         'DevHub Footer - Browsers section -  Enterprise',
     ],
 )


### PR DESCRIPTION
Reality is no longer a supported product, so he link was removed from the Footer. 