### PR TITLE
Add tests for deleting addons through the API

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -1,5 +1,6 @@
 {
    "base_url": "https://addons-dev.allizom.org",
+  "detail_extension_slug": "awesome-screenshot-plus-",
    "approved_addon_with_sources": "approved-src-code",
    "contributions_bad_request_message": "{\"contributions_url\":[\"URL domain must be one of [www.buymeacoffee.com, donate.mozilla.org, flattr.com, github.com, ko-fi.com, liberapay.com, www.micropayment.de, opencollective.com, www.patreon.com, www.paypal.com, paypal.me].\"]}",
    "image_validation_messages": [


### PR DESCRIPTION
This PR includes:
- invalid scenarios for deleting an addon through the API - for example, using an invalid delete token, deleting an addon with a user that is not the addon author
- reusing GUIDs to upload a new addon