### PR TITLE
Give extra time for langpacks to be processed before submission

### DIFF
--- a/tests/api/test_addon_uploads.py
+++ b/tests/api/test_addon_uploads.py
@@ -1128,7 +1128,7 @@ def test_upload_language_pack_with_authorized_user(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     # get the addon uuid generated after upload
     uuid = upload.json()['uuid']
@@ -1160,7 +1160,7 @@ def test_upload_language_pack_incorrect_category(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     # get the addon uuid generated after upload
     uuid = upload.json()['uuid']

--- a/tests/api/test_addon_uploads.py
+++ b/tests/api/test_addon_uploads.py
@@ -1212,9 +1212,10 @@ def test_upload_privileged_addon_with_unauthorized_account(base_url, session_aut
         assert 'You cannot submit a Mozilla Signed Extension' in create_addon.text
 
 
-@pytest.mark.create_session('api_user')
-def test_upload_privileged_addon_with_unauthorized_account(base_url, session_auth):
-    """Upload an addon signed with a mozilla signature using an unauthorized account"""
+@pytest.mark.serial
+@pytest.mark.create_session('staff_user')
+def test_upload_privileged_addon_with_authorized_account(base_url, session_auth):
+    """Upload an addon signed with a mozilla signature using an account holding the right permissions"""
     with open('sample-addons/mozilla-signed.xpi', 'rb') as file:
         upload = requests.post(
             url=f'{base_url}{_upload}',
@@ -1236,6 +1237,92 @@ def test_upload_privileged_addon_with_unauthorized_account(base_url, session_aut
             data=json.dumps(payload),
         )
         assert (
-            create_addon.status_code == 400
+            create_addon.status_code == 201
         ), f'Actual response: {create_addon.status_code}, {create_addon.text}'
-        assert 'You cannot submit a Mozilla Signed Extension' in create_addon.text
+        # check that the addon was created as a mozilla signed addon
+        assert (
+            create_addon.json()['latest_unlisted_version']['file'][
+                'is_mozilla_signed_extension'
+            ]
+            is True
+        )
+
+
+@pytest.mark.serial
+@pytest.mark.create_session('staff_user')
+def test_upload_addon_with_reserved_guid_authorized_account(base_url, session_auth):
+    """Upload an addon with a reserved guid using an account that holds the right permissions"""
+    # create a restricted GUID
+    guid = f'{reusables.get_random_string(10)}@mozilla.org'
+    manifest = {
+        **payloads.minimal_manifest,
+        'name': 'Reserved guid',
+        'browser_specific_settings': {'gecko': {'id': guid}},
+    }
+    api_helpers.make_addon(manifest)
+    with open('sample-addons/make-addon.zip', 'rb') as file:
+        upload = requests.post(
+            url=f'{base_url}{_upload}',
+            headers={'Authorization': f'Session {session_auth}'},
+            files={'upload': file},
+            data={'channel': 'unlisted'},
+        )
+        time.sleep(3)
+        upload.raise_for_status()
+        # get the addon uuid generated after upload
+        uuid = upload.json()['uuid']
+        payload = {**payloads.listed_addon_minimal(uuid)}
+        create_addon = requests.post(
+            url=f'{base_url}{_addon_create}',
+            headers={
+                'Authorization': f'Session {session_auth}',
+                'Content-Type': 'application/json',
+            },
+            data=json.dumps(payload),
+        )
+        print(create_addon.text)
+        assert (
+            create_addon.status_code == 201
+        ), f'Actual response: {create_addon.status_code}, {create_addon.text}'
+        # check that the addon was created with the guid set
+        assert create_addon.json()['guid'] == guid
+
+
+@pytest.mark.serial
+@pytest.mark.create_session('staff_user')
+@pytest.mark.clear_session
+def test_upload_addon_with_trademark_name_authorized_account(
+    selenium, base_url, session_auth
+):
+    """Upload an addon that includes the 'Firefox' trademark name with a user that holds the right permissions"""
+    # create an addon with a trademark name
+    addon_name = 'Firefox trademark'
+    manifest = {
+        **payloads.minimal_manifest,
+        'name': addon_name,
+    }
+    api_helpers.make_addon(manifest)
+    with open('sample-addons/make-addon.zip', 'rb') as file:
+        upload = requests.post(
+            url=f'{base_url}{_upload}',
+            headers={'Authorization': f'Session {session_auth}'},
+            files={'upload': file},
+            data={'channel': 'unlisted'},
+        )
+        time.sleep(3)
+        upload.raise_for_status()
+        uuid = upload.json()['uuid']
+        payload = payloads.listed_addon_minimal(uuid)
+        create_addon = requests.post(
+            url=f'{base_url}{_addon_create}',
+            headers={
+                'Authorization': f'Session {session_auth}',
+                'Content-Type': 'application/json',
+            },
+            data=json.dumps(payload),
+        )
+        # verify that the addon was created successfully
+        assert (
+            create_addon.status_code == 201
+        ), f'Actual response: {create_addon.status_code}, {create_addon.text}'
+        assert addon_name == create_addon.json()['name']['en-US']

--- a/tests/api/test_addon_uploads.py
+++ b/tests/api/test_addon_uploads.py
@@ -1083,9 +1083,11 @@ def test_upload_theme_with_wrong_license(base_url, session_auth):
 
 
 @pytest.mark.serial
-@pytest.mark.login('staff_user')
 def test_upload_language_pack_unauthorized_user(selenium, base_url):
     """Users not part of the language pack submission group are not allowed to submit langpacks"""
+    # get the sessionid for a regular user
+    page = Home(selenium, base_url).open().wait_for_page_to_load()
+    page.login('developer')
     session_auth = selenium.get_cookie('sessionid')
     with open('sample-addons/lang-pack.xpi', 'rb') as file:
         upload = requests.post(
@@ -1213,13 +1215,14 @@ def test_upload_privileged_addon_with_unauthorized_account(base_url, session_aut
 
 
 @pytest.mark.serial
-@pytest.mark.create_session('staff_user')
-def test_upload_privileged_addon_with_authorized_account(base_url, session_auth):
+@pytest.mark.login('staff_user')
+def test_upload_privileged_addon_with_authorized_account(selenium, base_url):
     """Upload an addon signed with a mozilla signature using an account holding the right permissions"""
+    session_auth = selenium.get_cookie('sessionid')
     with open('sample-addons/mozilla-signed.xpi', 'rb') as file:
         upload = requests.post(
             url=f'{base_url}{_upload}',
-            headers={'Authorization': f'Session {session_auth}'},
+            headers={'Authorization': f'Session {session_auth["value"]}'},
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
@@ -1231,7 +1234,7 @@ def test_upload_privileged_addon_with_authorized_account(base_url, session_auth)
         create_addon = requests.post(
             url=f'{base_url}{_addon_create}',
             headers={
-                'Authorization': f'Session {session_auth}',
+                'Authorization': f'Session {session_auth["value"]}',
                 'Content-Type': 'application/json',
             },
             data=json.dumps(payload),

--- a/tests/api/test_addon_uploads.py
+++ b/tests/api/test_addon_uploads.py
@@ -1283,7 +1283,6 @@ def test_upload_addon_with_reserved_guid_authorized_account(base_url, session_au
             },
             data=json.dumps(payload),
         )
-        print(create_addon.text)
         assert (
             create_addon.status_code == 201
         ), f'Actual response: {create_addon.status_code}, {create_addon.text}'


### PR DESCRIPTION
Sometimes, language pack submissions were failing with a "Upload not valid" error, which shouldn't be the case. This message can sometimes trigger when the upload hasn't been fully processed yet, so I'm increasing the wait time to see if this solves the issue. 
This PR is added on top of https://github.com/mozilla/addons-release-tests/pull/664 because I've only changed a wait time. 