### PR TITLE
Add two more tests for version source code uploads

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -2,7 +2,7 @@
    "base_url": "https://addons-dev.allizom.org",
    "detail_extension_slug": "awesome-screenshot-plus-",
    "duplicate_guid": "@contain-facebook",
-   "approved_addon_with_sources": "approved-src-code",
+   "approved_addon_with_sources": "jswszwpeoc",
    "contributions_bad_request_message": "{\"contributions_url\":[\"URL domain must be one of [www.buymeacoffee.com, donate.mozilla.org, flattr.com, github.com, ko-fi.com, liberapay.com, www.micropayment.de, opencollective.com, www.patreon.com, www.paypal.com, paypal.me].\"]}",
    "image_validation_messages": [
       "Images must be either PNG or JPG.",


### PR DESCRIPTION
This PR includes:
- uploading all types of supported source code files
- uploading source code for versions approved by reviewers, which should not be allowed 