### PR TITLE
Refactor install tests

### DIFF
--- a/pages/desktop/about_addons.py
+++ b/pages/desktop/about_addons.py
@@ -12,6 +12,9 @@ class AboutAddons(Page):
     _search_box_locator = (By.CSS_SELECTOR, '.main-search search-textbox')
     _extension_tab_button_locator = (By.CSS_SELECTOR, 'button[name = "extension"]')
     _theme_tab_button_locator = (By.CSS_SELECTOR, 'button[name = "theme"]')
+    _dictionary_tab_button_locator = (By.CSS_SELECTOR, 'button[name = "dictionary"]')
+    _langpack_tab_button_locator = (By.CSS_SELECTOR, 'button[name = "locale"]')
+    _extension_disable_toggle_locator = (By.CLASS_NAME, 'extension-enable-button')
     _enabled_theme_status_locator = (By.CLASS_NAME, 'card.addon')
     _installed_addon_cards_locator = (By.CSS_SELECTOR, '.card.addon')
     _enabled_theme_image_locator = (By.CLASS_NAME, 'card-heading-image')
@@ -55,6 +58,25 @@ class AboutAddons(Page):
                 (By.CLASS_NAME, 'list-section-heading'), 'Enabled'
             )
         )
+
+    def click_dictionaries_side_button(self):
+        self.find_element(*self._dictionary_tab_button_locator).click()
+        self.wait.until(
+            EC.text_to_be_present_in_element(
+                (By.CLASS_NAME, 'list-section-heading'), 'Enabled'
+            )
+        )
+
+    def click_language_side_button(self):
+        self.find_element(*self._langpack_tab_button_locator).click()
+        self.wait.until(
+            EC.text_to_be_present_in_element(
+                (By.CLASS_NAME, 'list-section-heading'), 'Enabled'
+            )
+        )
+
+    def disable_extension(self):
+        self.find_element(*self._extension_disable_toggle_locator).click()
 
     @property
     def installed_addon_cards(self):

--- a/tests/frontend/test_install.py
+++ b/tests/frontend/test_install.py
@@ -5,23 +5,14 @@ from pages.desktop.about_addons import AboutAddons
 from pages.desktop.frontend.details import Detail
 
 
-@pytest.mark.nondestructive
-@pytest.mark.parametrize(
-    'addon_type, name_type',
-    [
-        ['weather-stage', 'Weather'],
-        ['japanese-tattoo', 'Japanese Tattoo'],
-        ['release-langpack', 'Release Langpack'],
-        ['release_dictionary', 'Release Dictionary'],
-    ],
-)
-def test_addon_install(
-    base_url, selenium, firefox, firefox_notifications, addon_type, name_type
+def test_install_uninstall_extension(
+    selenium, base_url, firefox, firefox_notifications, wait
 ):
-    """Test that navigates to an addon and installs it."""
-    selenium.get(f'{base_url}/addon/{addon_type}')
-    addon = Detail(selenium, base_url)
-    assert name_type in addon.name
+    """Open an extension detail page, install it and then uninstall it"""
+    selenium.get(f'{base_url}/addon/bloody-vikings/')
+    addon = Detail(selenium, base_url).wait_for_page_to_load()
+    amo_addon_name = addon.name
+    assert amo_addon_name == 'Bloody Vikings!'
     assert addon.is_compatible
     addon.install()
     firefox.browser.wait_for_notification(
@@ -30,14 +21,170 @@ def test_addon_install(
     firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallComplete
     ).close()
+    # check that the install button state changed to "Remove"
     assert 'Remove' in addon.button_text
-    # Reused the 'install()` method although the next step reflects an uninstall action.
+    # open the manage Extensions page in about:addons to verify that the extension was installed correctly
+    selenium.switch_to.new_window('tab')
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium).wait_for_page_to_load()
+    about_addons.click_extensions_side_button()
+    wait.until(lambda _: amo_addon_name == about_addons.installed_addon_name[0].text)
+    # go back to the addon detail page on AMO to uninstall the addon
+    selenium.switch_to.window(selenium.window_handles[0])
+    # reused the 'install()` method although the next step reflects an uninstall action.
     addon.install()
-    # using a 'try - except AssertionError' method because the install button text is different for Themes.
-    try:
-        assert 'Add to Firefox' in addon.button_text
-    except AssertionError:
-        assert 'Install Theme' in addon.button_text
+    # check that the install button state changed back to "Add to Firefox"
+    wait.until(lambda _: 'Add to Firefox' in addon.button_text)
+    # open the manage Extensions page in about:addons to verify that the extension is no longer in the list
+    selenium.switch_to.window(selenium.window_handles[1])
+    with pytest.raises(IndexError):
+        wait.until(
+            lambda _: amo_addon_name == about_addons.installed_addon_name[0].text
+        )
+
+
+def test_enable_disable_extension(
+    selenium, base_url, firefox, firefox_notifications, wait
+):
+    """Open an extension detail page, install it, disable it from about:addons then enable it back in AMO"""
+    selenium.get(f'{base_url}/addon/bloody-vikings/')
+    addon = Detail(selenium, base_url).wait_for_page_to_load()
+    addon.install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallComplete
+    ).close()
+    # open the manage Extensions page in about:addons and Disable the extension
+    selenium.switch_to.new_window('tab')
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium).wait_for_page_to_load()
+    about_addons.click_extensions_side_button()
+    about_addons.disable_extension()
+    # verify that about:addons marks the extension as disabled -  (disabled) appended to addon name
+    wait.until(
+        lambda _: about_addons.installed_addon_name[0].text
+        == 'Bloody Vikings! (disabled)'
+    )
+    # go back to the addon detail page on AMO to Enable the addon
+    selenium.switch_to.window(selenium.window_handles[0])
+    assert addon.button_text == 'Enable'
+    addon.install()
+    # check that the install button state changed back to "Remove"
+    wait.until(lambda _: 'Remove' in addon.button_text)
+    # open the manage Extensions page in about:addons to verify that the extension was re-enabled
+    selenium.switch_to.window(selenium.window_handles[1])
+    wait.until(lambda _: about_addons.installed_addon_name[0].text == 'Bloody Vikings!')
+
+
+def test_install_uninstall_theme(
+    selenium, base_url, firefox, firefox_notifications, wait
+):
+    """Open a theme detail page, install it and then uninstall it"""
+    selenium.get(f'{base_url}/addon/japanese-tattoo/')
+    addon = Detail(selenium, base_url).wait_for_page_to_load()
+    amo_theme_name = addon.name
+    assert amo_theme_name == 'Japanese Tattoo'
+    assert addon.is_compatible
+    addon.install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallComplete
+    ).close()
+    # check that the install button state changed to "Remove"
+    assert 'Remove' in addon.button_text
+    # open the manage Themes page in about:addons to verify that the theme was installed correctly
+    selenium.switch_to.new_window('tab')
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium).wait_for_page_to_load()
+    about_addons.click_themes_side_button()
+    wait.until(lambda _: amo_theme_name == about_addons.installed_addon_name[0].text)
+    # go back to the addon detail page on AMO to uninstall the theme
+    selenium.switch_to.window(selenium.window_handles[0])
+    # reused the 'install()` method although the next step reflects an uninstall action.
+    addon.install()
+    # check that the install button state changed back to "Install Theme"
+    wait.until(lambda _: 'Install Theme' in addon.button_text)
+    # open the manage Themes page in about:addons to verify that the theme is no longer in the list
+    selenium.switch_to.window(selenium.window_handles[1])
+    assert amo_theme_name not in [el.text for el in about_addons.installed_addon_name]
+
+
+def test_install_uninstall_dictionary(
+    selenium, base_url, firefox, firefox_notifications, wait
+):
+    """Open a dictionary detail page, install it and then uninstall it"""
+    selenium.get(f'{base_url}/addon/release_dictionary/')
+    addon = Detail(selenium, base_url).wait_for_page_to_load()
+    amo_dict_name = addon.name
+    assert amo_dict_name == 'release dictionary'
+    assert addon.is_compatible
+    addon.install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallComplete
+    ).close()
+    # check that the install button state changed to "Remove"
+    assert 'Remove' in addon.button_text
+    # open the manage Dictionaries page in about:addons to verify that the dictionary was installed correctly
+    selenium.switch_to.new_window('tab')
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium).wait_for_page_to_load()
+    about_addons.click_dictionaries_side_button()
+    wait.until(lambda _: amo_dict_name == about_addons.installed_addon_name[0].text)
+    # go back to the addon detail page on AMO to uninstall the dictionary
+    selenium.switch_to.window(selenium.window_handles[0])
+    # reused the 'install()` method although the next step reflects an uninstall action.
+    addon.install()
+    # check that the install button state changed back to "Add to Firefox"
+    wait.until(lambda _: 'Add to Firefox' in addon.button_text)
+    # open the manage Dictionaries page in about:addons to verify that the dictionary is no longer in the list
+    selenium.switch_to.window(selenium.window_handles[1])
+    with pytest.raises(IndexError):
+        wait.until(lambda _: amo_dict_name == about_addons.installed_addon_name[0].text)
+
+
+def test_install_uninstall_langpack(
+    selenium, base_url, firefox, firefox_notifications, wait
+):
+    """Open a language pack detail page, install it and then uninstall it"""
+    selenium.get(f'{base_url}/addon/release-langpack/')
+    addon = Detail(selenium, base_url).wait_for_page_to_load()
+    amo_langpack_name = addon.name
+    assert amo_langpack_name == 'Release lang pack'
+    assert addon.is_compatible
+    addon.install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallConfirmation
+    ).install()
+    firefox.browser.wait_for_notification(
+        firefox_notifications.AddOnInstallComplete
+    ).close()
+    # check that the install button state changed to "Remove"
+    assert 'Remove' in addon.button_text
+    # open the manage Language page in about:addons to verify that the langpack was installed correctly
+    selenium.switch_to.new_window('tab')
+    selenium.get('about:addons')
+    about_addons = AboutAddons(selenium).wait_for_page_to_load()
+    about_addons.click_language_side_button()
+    wait.until(lambda _: amo_langpack_name == about_addons.installed_addon_name[0].text)
+    # go back to the addon detail page on AMO to uninstall the dictionary
+    selenium.switch_to.window(selenium.window_handles[0])
+    # reused the 'install()` method although the next step reflects an uninstall action.
+    addon.install()
+    # check that the install button state changed back to "Add to Firefox"
+    wait.until(lambda _: 'Add to Firefox' in addon.button_text)
+    # open the manage Language page in about:addons to verify that the langpack is no longer in the list
+    selenium.switch_to.window(selenium.window_handles[1])
+    with pytest.raises(IndexError):
+        wait.until(
+            lambda _: amo_langpack_name == about_addons.installed_addon_name[0].text
+        )
 
 
 def test_about_addons_install_extension(


### PR DESCRIPTION
The previous install tests were parameterized to run with each add-on type, but that had some limitations in the more varied verifications we could do depending on the addon type installed.

I've chosen to split the tests and include more verifications, such as making sure that the addons are listed/delisted in their respective tabs in about:addons after installation/uninstallation. 

I've also added a new test that checks the Enable/Disable function in AMO and about:addons. 