### PR TITLE
Remove site status from devhub footer links test

### DIFF
--- a/tests/devhub/test_devhub_home.py
+++ b/tests/devhub/test_devhub_home.py
@@ -449,7 +449,6 @@ def test_devhub_mozilla_footer_link(base_url, selenium):
             'discourse',
             '/about',
             'review_guide',
-            'mozilla.org',  # temporary
         ]
     ),
     ids=[
@@ -461,7 +460,6 @@ def test_devhub_mozilla_footer_link(base_url, selenium):
         'DevHub Footer - Addons section -  Forum',
         'DevHub Footer - Addons section -  Report a bug',
         'DevHub Footer - Addons section -  Review Guide',
-        'DevHub Footer - Addons section -  Site status',
     ],
 )
 @pytest.mark.nondestructive


### PR DESCRIPTION
The site status link has been removed from the devhub, so we should also remove it from our tests. 