### PR TITLE
Add test for user profile addon cards

### DIFF
--- a/pages/desktop/frontend/search.py
+++ b/pages/desktop/frontend/search.py
@@ -116,7 +116,16 @@ class Search(Page):
             _search_item_name_locator = (By.CSS_SELECTOR, '.SearchResult-link')
             _promoted_badge_locator = (By.CSS_SELECTOR, '.PromotedBadge')
             _promoted_badge_label_locator = (By.CSS_SELECTOR, '.PromotedBadge-label')
-            _users_locator = (By.CLASS_NAME, 'SearchResult-users-text')
+            _users_locator = (By.CLASS_NAME, 'SearchResult-users')
+            _users_number_locator = (By.CLASS_NAME, 'SearchResult-users-text')
+            _icon_locator = (By.CLASS_NAME, 'SearchResult-icon')
+            _rating_stars_locator = (By.CLASS_NAME, 'SearchResult-rating')
+            _author_locator = (By.CLASS_NAME, 'SearchResult-author')
+            _summary_locator = (By.CLASS_NAME, 'SearchResult-summary')
+
+            @property
+            def search_name(self):
+                return self.find_element(*self._search_item_name_locator)
 
             @property
             def name(self):
@@ -134,7 +143,7 @@ class Search(Page):
 
             @property
             def users(self):
-                users = self.find_element(*self._users_locator).text
+                users = self.find_element(*self._users_number_locator).text
                 return int(users.split()[0].replace(',', '').replace('users', ''))
 
             @property
@@ -142,6 +151,26 @@ class Search(Page):
                 """Returns the rating"""
                 rating = self.find_element(*self._rating_locator).get_property('title')
                 return float(rating.split()[1])
+
+            @property
+            def search_result_icon(self):
+                return self.find_element(*self._icon_locator)
+
+            @property
+            def search_result_rating_stars(self):
+                return self.find_element(*self._rating_stars_locator)
+
+            @property
+            def search_result_author(self):
+                return self.find_element(*self._author_locator)
+
+            @property
+            def search_result_users(self):
+                return self.find_element(*self._users_locator)
+
+            @property
+            def search_result_summary(self):
+                return self.find_element(*self._summary_locator)
 
             @property
             def promoted_badge(self):

--- a/pages/desktop/frontend/users.py
+++ b/pages/desktop/frontend/users.py
@@ -62,11 +62,20 @@ class User(Base):
         _user_biography_locator = (By.CSS_SELECTOR, '.UserProfile-biography')
         _user_profile_edit_link_locator = (By.CSS_SELECTOR, '.UserProfile-edit-link')
         _user_extensions_card_locator = (By.CSS_SELECTOR, '.AddonsCard--vertical')
+        _user_extensions_card_header_locator = (
+            By.CSS_SELECTOR,
+            '.AddonsCard--vertical .Card-header-text',
+        )
         _user_extensions_results_locator = (
             By.CSS_SELECTOR,
             '.AddonsCard--vertical .SearchResult',
         )
         _user_themes_card_locator = (By.CSS_SELECTOR, '.AddonsByAuthorsCard--theme')
+        _user_themes_card_header_locator = (
+            By.CSS_SELECTOR,
+            '.AddonsByAuthorsCard--theme .Card-header-text',
+        )
+        _user_themes_results_locator = (By.CLASS_NAME, 'SearchResult--theme')
         _user_reviews_card_locator = (By.CSS_SELECTOR, '.UserProfile-reviews')
         _extensions_pagination_locator = (
             By.CSS_SELECTOR,
@@ -200,6 +209,10 @@ class User(Base):
             return Search(self.driver, self.page.base_url).wait_for_page_to_load()
 
         @property
+        def user_extensions_card_header(self):
+            return self.find_element(*self._user_extensions_card_header_locator).text
+
+        @property
         def user_extensions_results(self):
             items = self.find_elements(*self._user_extensions_results_locator)
             return [
@@ -213,6 +226,20 @@ class User(Base):
         def user_themes(self):
             self.find_element(*self._user_themes_card_locator)
             return Search(self.driver, self.page.base_url).wait_for_page_to_load()
+
+        @property
+        def user_themes_card_header(self):
+            return self.find_element(*self._user_themes_card_header_locator).text
+
+        @property
+        def user_themes_results(self):
+            items = self.find_elements(*self._user_themes_results_locator)
+            return [
+                Search(
+                    self.driver, self.page.base_url
+                ).SearchResultList.ResultListItems(self, el)
+                for el in items
+            ]
 
         @property
         def extensions_pagination(self):

--- a/tests/frontend/test_users.py
+++ b/tests/frontend/test_users.py
@@ -469,7 +469,7 @@ def test_user_addon_cards_for_users_with_multiple_roles(base_url, selenium, vari
         assert theme.search_result_users.is_displayed()
     # verify that the user profile ratings card is not displayed when viewed by another user
     with pytest.raises(
-        NoSuchElementException,
+        Exception,
         match='Message: Unable to locate element: .UserProfile-reviews',
     ):
         selenium.find_element(By.CLASS_NAME, 'UserProfile-reviews')

--- a/tests/frontend/test_users.py
+++ b/tests/frontend/test_users.py
@@ -450,7 +450,7 @@ def test_user_addon_cards_for_users_with_multiple_roles(base_url, selenium, vari
     be hidden when the profile is viewed by another user"""
     user_profile = variables['developer_and_artist_role']
     selenium.get(f'{base_url}/user/{user_profile}')
-    user = User(selenium, base_url).wait_for_user_to_load()
+    user = User(selenium, base_url)
     user_profile_name = user.user_display_name.text
     # check that extensions results have the following properties displayed:
     assert f'Extensions by {user_profile_name}' in user.view.user_extensions_card_header
@@ -468,7 +468,10 @@ def test_user_addon_cards_for_users_with_multiple_roles(base_url, selenium, vari
         assert theme.search_result_icon.is_displayed()
         assert theme.search_result_users.is_displayed()
     # verify that the user profile ratings card is not displayed when viewed by another user
-    with pytest.raises(NoSuchElementException):
+    with pytest.raises(
+        NoSuchElementException,
+        match='Message: Unable to locate element: .UserProfile-reviews',
+    ):
         selenium.find_element(By.CLASS_NAME, 'UserProfile-reviews')
 
 

--- a/tests/frontend/test_users.py
+++ b/tests/frontend/test_users.py
@@ -444,6 +444,36 @@ def test_non_developer_user_profile_is_not_public(base_url, selenium, variables)
 
 @pytest.mark.serial
 @pytest.mark.nondestructive
+def test_user_addon_cards_for_users_with_multiple_roles(base_url, selenium, variables):
+    """Users who are both extension developers and theme artists should have the Extensions
+    and Themes cards displayed on their profiles. Additionally, the User reviews card should
+    be hidden when the profile is viewed by another user"""
+    user_profile = variables['developer_and_artist_role']
+    selenium.get(f'{base_url}/user/{user_profile}')
+    user = User(selenium, base_url).wait_for_user_to_load()
+    user_profile_name = user.user_display_name.text
+    # check that extensions results have the following properties displayed:
+    assert f'Extensions by {user_profile_name}' in user.view.user_extensions_card_header
+    for extension in user.view.user_extensions_results:
+        assert extension.search_name.is_displayed()
+        assert extension.search_result_icon.is_displayed()
+        assert extension.search_result_rating_stars.is_displayed()
+        assert user_profile_name in extension.search_result_author.text
+        assert extension.search_result_users.is_displayed()
+        assert extension.search_result_summary.is_displayed()
+    # check that themes results have the following properties displayed:
+    assert f'Themes by {user_profile_name}' in user.view.user_themes_card_header
+    for theme in user.view.user_themes_results:
+        assert theme.search_name.is_displayed()
+        assert theme.search_result_icon.is_displayed()
+        assert theme.search_result_users.is_displayed()
+    # verify that the user profile ratings card is not displayed when viewed by another user
+    with pytest.raises(NoSuchElementException):
+        selenium.find_element(By.CLASS_NAME, 'UserProfile-reviews')
+
+
+@pytest.mark.serial
+@pytest.mark.nondestructive
 def test_user_profile_extensions_card(base_url, selenium, variables):
     page = variables['developer_and_artist_role']
     selenium.get(f'{base_url}/user/{page}')


### PR DESCRIPTION
I've added a new test in the user profiles suite covering the addon cards (extensions and themes) for users that are both developers and theme artists. 