### PR TITLE
Add variables and config to run parallel tests on AMO dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,36 @@ jobs:
       - store_artifacts:
           path: api_submission_tests.html
 
+  # a set of frontend regression tests to be run on AMO -dev once per day (set as nightly tests)
+  frontend_dev_parallel_tests:
+    executor:
+      name: win/default
+      size: "large"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Upgrade pip
+          command: py -3.9 -m pip install --upgrade pip --user
+      - run:
+          name: Install requirements
+          command: py -3.9 -m pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox-nightly --pre
+      - run:
+          name: Run frontend parallel tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 4 --reruns 2
+          command: py -3.9 -m pytest tests\frontend -m "not serial and not prod_only" --driver Firefox --variables translations.json --variables dev.json --html=frontend-dev-parallel-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: frontend-dev-parallel-test-results.html
+
 workflows:
   commit_workflow:
     when:
@@ -317,3 +347,11 @@ workflows:
       - sanity_serial_tests: # # will run after the hold job is approved
           requires:
             - hold
+  # scheduled in CircleCI Project settings to run once a day
+  scheduled_dev_regression_tests:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "scheduled_dev_regression_tests", << pipeline.schedule.name >> ]
+    jobs:
+      - frontend_dev_parallel_tests

--- a/dev.json
+++ b/dev.json
@@ -1,21 +1,57 @@
 {
-   "base_url": "https://addons-dev.allizom.org",
-   "detail_extension_slug": "awesome-screenshot-plus-",
-   "duplicate_guid": "@contain-facebook",
-   "approved_addon_with_sources": "jswszwpeoc",
-   "api_post_valid_author": 10642370,
-   "api_post_author_no_display_name": 10642339,
-   "api_post_author_no_dev_agreement": 10642340,
-   "api_post_additional_author": 10640485,
-   "contributions_bad_request_message": "{\"contributions_url\":[\"URL domain must be one of [www.buymeacoffee.com, donate.mozilla.org, flattr.com, github.com, ko-fi.com, liberapay.com, www.micropayment.de, opencollective.com, www.patreon.com, www.paypal.com, paypal.me].\"]}",
-   "image_validation_messages": [
+  "base_url": "https://addons-dev.allizom.org",
+
+  "search_term": "Flagfox",
+
+  "not_found_page_title": "Oops! We can’t find that page",
+
+  "secondary_hero_title": "Extensions are like apps for Firefox.",
+  "secondary_hero_summary": "They add features to Firefox to make browsing faster, safer, or just plain fun",
+
+  "detail_extension_slug": "awesome-screenshot-plus-",
+  "detail_extension_name": "Awesome Screenshot Plus - Capture, Annotate & More",
+  "by_firefox_addon": "addon_by_firefox",
+  "experimental_addon": "experimental_addon",
+  "addon_detail_guid": "{f2cd2fe0-0c62-40bd-8e28-2f4d7fc0ad43}",
+  "addon_detail_id": "622217",
+  "addon_unicode_slug": "웃统一码翻译翻译",
+  "lower_firefox_version":"lower_firefox ",
+  "higher_firefox_version": "higher_firefox",
+  "incompatible_platform": "platform_incompat",
+  "addon_with_stats": "facebook-container",
+  "addon_without_stats": "addon_without_stats ",
+  "theme_detail_page": "full-moon-kitty",
+  "support_site_link": "https://www.awesomescreenshot.com/",
+  "ratings_card_summary": "How are you enjoying Awesome Screenshot Plus - Capture, Annotate & More?",
+  "contribute_utm_param": "utm_content=product-page-contribute&utm_medium=referral&utm_source=addons.mozilla.org",
+  "contribute_card_summary": "The developer of this extension asks that you help support its continued development by making a small contribution.",
+  "install_warning_message": "This add-on is not actively monitored for security by Mozilla. Make sure you trust it before installing.",
+
+  "static_page_blocked_addon": "https://addons-dev.allizom.org/en-US/firefox/blocked-addon/%7B904e7c93-3726-4f05-a357-cd2ceb32dedf%7D/",
+  "blocked_addon_name": "Awaiting review",
+  "static_page_login_expired_text": "Login authentication has expired. Reload the page to continue without authentication, or login again using the Log In link at the top of the page.",
+
+  "addon_version_page_url": "https://addons-dev.allizom.org/en-US/firefox/addon/dark22reader/versions/",
+  "version_page_notice_message": "Be careful with old versions! These versions are displayed for testing and reference purposes.\nYou should always use the latest version of an add-on.",
+  "non_recommended_addon": "non-recommended",
+  "addon_version_install": "ghosttext",
+
+
+  "duplicate_guid": "@contain-facebook",
+  "approved_addon_with_sources": "jswszwpeoc",
+  "api_post_valid_author": 10642370,
+  "api_post_author_no_display_name": 10642339,
+  "api_post_author_no_dev_agreement": 10642340,
+  "api_post_additional_author": 10640485,
+  "contributions_bad_request_message": "{\"contributions_url\":[\"URL domain must be one of [www.buymeacoffee.com, donate.mozilla.org, flattr.com, github.com, ko-fi.com, liberapay.com, www.micropayment.de, opencollective.com, www.patreon.com, www.paypal.com, paypal.me].\"]}",
+  "image_validation_messages": [
       "Images must be either PNG or JPG.",
       "Images must be either PNG or JPG.",
       "Images cannot be animated.",
       "Upload a valid image. The file you uploaded was either not an image or a corrupted image.",
       "Images must be square (same width and height)."
    ],
-   "name_translations_from_locales_xpi": {
+  "name_translations_from_locales_xpi": {
        "ar": "«غرير الخصوصية»",
        "de": "German name from _locales",
        "en-US": "Privacy Badger",

--- a/scripts/reusables.py
+++ b/scripts/reusables.py
@@ -29,3 +29,13 @@ def current_date():
     today = datetime.datetime.today()
     time = today.strftime('%b %#d, %Y')
     return time
+
+
+def convert_bytes(size):
+    """Used for converting addon file sizes from bytes (as returned by the 'file.length' property) to units
+      from on AMO (usually KB or MB) for the purpose of comparing that AMO is showing the correct file size"""
+    for x in ['bytes', 'KB', 'MB']:
+        if size < 1024.0:
+            return "%3.2f %s" % (size, x)
+        size /= 1024.0
+    return size

--- a/tests/frontend/test_search.py
+++ b/tests/frontend/test_search.py
@@ -323,7 +323,7 @@ def test_top_rated_recommended_extensions(base_url, selenium, variables):
     page.search.search_for('')
     # verify if sort filter applied correctly
     for result in search_page.result_list.extensions:
-        assert getattr(result, 'rating') > 4
+        assert getattr(result, 'rating') >= 4
     # verify that no themes are displayed
     assert len(search_page.result_list.themes) == 0
     # verify badge type
@@ -344,7 +344,7 @@ def test_top_rated_recommended_themes(base_url, selenium, variables):
     page.search.search_for('')
     # verify if sort filter applied correctly
     for result in search_page.result_list.extensions:
-        assert getattr(result, 'rating') > 4
+        assert getattr(result, 'rating') >= 4
     # verify that all elements are themes
     assert len(search_page.result_list.themes) == len(
         search_page.result_list.extensions

--- a/tests/frontend/test_versions.py
+++ b/tests/frontend/test_versions.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 
 from pages.desktop.frontend.versions import Versions
+from scripts import reusables
 
 
 @pytest.mark.nondestructive
@@ -84,22 +85,20 @@ def test_license_link(selenium, base_url, variables):
 
 @pytest.mark.nondestructive
 def test_current_version(selenium, base_url, variables):
-    addon_url = 'addon/devhub-listed-ext-07-30/'
+    addon_url = f'addon/{variables["addon_version_install"]}/'
     # get info from api
     response = requests.get(f'{base_url}/api/v5/addons/{addon_url}')
     addon_version = response.json()['current_version']['version']
-    addon_size_kb = (
-        str(round(response.json()['current_version']['file']['size'] / 1024, 2)) + ' KB'
-    )
+    addon_size = reusables.convert_bytes(response.json()['current_version']['file']['size'])
     api_date = response.json()['current_version']['file']['created'][:10]
     # process the date to have the same format as in frontend
     api_date = datetime.strptime(api_date, '%Y-%m-%d')
     api_processed_date = datetime.strftime(api_date, "%b %#d, %Y")
     # verify info displayed in page
     page = Versions(selenium, base_url)
-    selenium.get(variables['addon_version_page_url'])
+    selenium.get(f'{base_url}/addon/{variables["addon_version_install"]}/versions/')
     assert page.versions_list[0].version_number == addon_version
-    assert addon_size_kb == page.versions_list[0].version_size
+    assert addon_size == page.versions_list[0].version_size
     assert page.versions_list[0].released_date == api_processed_date
 
 

--- a/translations.json
+++ b/translations.json
@@ -1,5 +1,4 @@
 {
-  "base_url": "https://addons.allizom.org",
   "it": {
     "header": {
       "blog_link": "Blog sui componenti aggiuntivi per Firefox",


### PR DESCRIPTION
We used to run our test only on AMO stage where the test data is more reliable. After a discussion with the dev team, we decided to add some regression suites to run on AMO -dev as well. The tests will run once a day (over night).

This PR includes:
- adding variables to `dev.json` with test data from AMO dev
- creating the CircleCI config and scheduling to run frontend parallel tests on AMO -dev - see https://app.circleci.com/pipelines/github/mozilla/addons-release-tests/1756/workflows/04486e7c-ab2e-4612-94ce-23d6fa5a9e59/jobs/6548
- small refactoring to some tests to make them compatible between dev and stage

The test failure is unrelated and was fixed in https://github.com/mozilla/addons-release-tests/pull/682
