### PR TITLE
downgrade pytest-html due to encoding error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pytest-dependency==0.5.1
 pytest-firefox==0.1.1
 pytest-forked==1.4.0
 pytest-fxa==1.4.0
-pytest-html==3.2.0
+pytest-html==3.1.1
 pytest-instafail==0.4.2
 pytest-metadata==2.0.2
 pytest-rerunfailures==10.2


### PR DESCRIPTION
Since the upgrade to `pytes-html = 3.2.0` there have been some intermittent encoding errors raised from `charmap` (the encoding /decoding utility included with Windows operating systems). We should wait for a future release before we upgrade again. 