### PR TITLE
Add devhub homepage tests to dev regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run collections serial tests
           environment:
@@ -51,7 +51,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run ratings serial tests
           environment:
@@ -81,7 +81,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run user serial tests
           environment:
@@ -111,7 +111,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run frontend parallel tests
           environment:
@@ -142,7 +142,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run devhub parallel tests
           environment:
@@ -172,7 +172,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run addon submissions tests
           environment:
@@ -292,7 +292,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run frontend parallel tests
           environment:
@@ -322,7 +322,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run user serial tests
           environment:
@@ -352,7 +352,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run collections serial tests
           environment:
@@ -382,7 +382,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run ratings serial tests
           environment:
@@ -413,7 +413,7 @@ jobs:
           command: choco install selenium-gecko-driver
       - run:
           name: Install Firefox
-          command: choco install firefox-nightly --pre
+          command: choco install firefox-nightly --pre --ignore-checksums
       - run:
           name: Run devhub parallel tests
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,6 +393,37 @@ jobs:
       - store_artifacts:
           path: ratings-dev-test-results.html
 
+ # tests that are covering the developer hub homepage on AMO -dev
+  devhub_dev_parallel_tests:
+    executor:
+      name: win/default
+      version: "previous"
+      size: "large"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Upgrade pip
+          command: py -3.9 -m pip install --upgrade pip --user
+      - run:
+          name: Install requirements
+          command: py -3.9 -m pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox-nightly --pre
+      - run:
+          name: Run devhub parallel tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 4 --reruns 2
+          command: py -3.9 -m pytest tests\devhub\test_devhub_home.py --driver Firefox --variables dev.json --html=devhub-dev-parallel-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: devhub-dev-parallel-test-results.html
+
 workflows:
   commit_workflow:
     when:
@@ -448,3 +479,4 @@ workflows:
       - user_dev_serial_tests
       - collections_dev_serial_tests
       - ratings_dev_serial_tests
+      - devhub_dev_parallel_tests

--- a/dev.json
+++ b/dev.json
@@ -5,6 +5,8 @@
 
   "not_found_page_title": "Oops! We can’t find that page",
 
+  "fxa_login_page": "accounts.stage.mozaws.net",
+
   "secondary_hero_title": "Extensions are like apps for Firefox.",
   "secondary_hero_summary": "They add features to Firefox to make browsing faster, safer, or just plain fun",
 
@@ -88,6 +90,47 @@
   "public_collection_popularity":"https://addons-dev.allizom.org/api/v5/accounts/account/4757633/collections/privacy-matters/addons/?page=1&sort=-popularity",
   "collection_reused_url_warning": "This custom URL is already in use by another one of your collections.",
   "collection_invalid_custom_url_warning": "The custom URL must consist of letters, numbers, underscores or hyphens.",
+
+  "devhub_overview_header": "Customize Firefox",
+  "devhub_overview_summary": "Whether you’re new to extension development, polishing up or porting an existing extension or theme, or creating a custom enterprise solution, we’ve got the resources to support you.",
+  "devhub_my_addons_section_paragraph": "This is where you view and manage your add-ons and themes. To publish your first add-on, click \"Submit Your First Add-on\" or \"Submit Your First Theme\".",
+  "devhub_content_header": "Ready to submit or manage your extension?",
+  "devhub_content_summary": "Sign in to the Developer Hub to submit or manage extensions and themes",
+  "devhub_get_involved_header": "Get involved",
+  "devhub_get_involved_summary": "Connect with thousands of developers and discover more ways you can contribute to the extension ecosystem.",
+  "devhub_newsletter_header": "Extensions Developers Newsletter",
+  "devhub_newsletter_info_text": "Stay up-to-date on news and events for Firefox extension developers.",
+  "devhub_signup_confirmation_title": "Thanks!",
+  "devhub_signup_confirmation_message": "If you haven’t previously confirmed a subscription to a Mozilla-related newsletter you may have to do so. Please check your inbox or your spam filter for an email from us.",
+  "devhub_newsletter_email": "test-devauto-news@restmail.net",
+  "devhub_logged_in_banner_header": "Build best-in-class extensions and themes",
+  "devhub_logged_in_banner_text": "Whether you’re new to extension development, polishing up or porting an existing extension or theme, or creating a custom enterprise solution, we’ve got the resources to support you.",
+  "devhub_resources_doc_links": [
+    "/Mozilla/Add-ons/WebExtensions",
+    "extensionworkshop-dev.allizom.org/extension-basics/",
+    "extensionworkshop-dev.allizom.org/documentation/themes/"
+  ],
+  "devhub_resources_tools_links": [
+    "/github.com/mozilla/web-ext",
+    "/developers/addon/validate",
+    "/developers/addon/api/key/"
+  ],
+  "devhub_resources_promote_links": [
+    "/promote-your-add-ons-with-the-get-the-add-on-button/",
+    "extensionworkshop-dev.allizom.org/documentation/publish/recommended-extensions/"
+  ],
+  "devhub_resources_review_addons_text": "Volunteer reviewers help keep add-ons safe and reliable to use. They enjoy great perks too!",
+  "devhub_resources_write_some_code_text": "Help make add-ons better by contributing your coding skills.",
+  "devhub_resources_participate_text": "You don't need coding skills to help keep Firefox the most customizable browser available!",
+  "devhub_submit_addon_agreement_header": "Add-on Distribution Agreement",
+  "devhub_submit_addon_distribution_header": "How to Distribute this Version",
+
+  "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
+  "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",
+  "listed_addon_summary_en": "Listed add-on summary set at add-on creation time",
+  "listed_addon_description_en": "Listed add-on description set at add-on creation time",
+  "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
+  "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
 
   "duplicate_guid": "@contain-facebook",
   "approved_addon_with_sources": "jswszwpeoc",

--- a/stage.json
+++ b/stage.json
@@ -5,6 +5,8 @@
 
   "not_found_page_title": "Oops! We can’t find that page",
 
+  "fxa_login_page": "accounts.firefox.com",
+
   "detail_extension_slug": "ghostery",
   "detail_extension_name": "Ghostery - Privacy Ad Blocker",
   "addon_with_stats": "facebook-container",

--- a/tests/devhub/test_devhub_home.py
+++ b/tests/devhub/test_devhub_home.py
@@ -95,7 +95,7 @@ def test_devhub_content_login_link(selenium, base_url, variables):
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     page.click_content_login_link()
     # verify that the link opens the FxA login page
-    page.wait_for_current_url('accounts.firefox.com')
+    page.wait_for_current_url(variables['fxa_login_page'])
 
 
 @pytest.mark.sanity
@@ -175,7 +175,7 @@ def test_devhub_my_addons_list_items(selenium, base_url, wait):
         try:
             assert 'Not yet rated' in addon.my_addon_rating_text.text
         except AssertionError:
-            assert 'reviews' in addon.my_addon_rating_text.text
+            assert 'review' in addon.my_addon_rating_text.text
             assert addon.my_addon_rating_stars.is_displayed()
 
 


### PR DESCRIPTION
This PR includes:
- circleci config
- variables for AMO -dev
- small test updates to make the compatible 