### PR TITLE
Amo dev submission tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,6 +424,36 @@ jobs:
       - store_artifacts:
           path: devhub-dev-parallel-test-results.html
 
+  # tests covering addon submissions through DevHub from AMO dev
+  addon_submissions_dev_tests:
+    executor:
+      name: win/default
+      size: "large"
+    working_directory: ~/addons-release-tests/
+    steps:
+      - checkout
+      - run:
+          name: Upgrade pip
+          command: py -3.9 -m pip install --upgrade pip --user
+      - run:
+          name: Install requirements
+          command: py -3.9 -m pip install --no-deps -r ./requirements.txt
+      - run:
+          name: Install geckodriver
+          command: choco install selenium-gecko-driver
+      - run:
+          name: Install Firefox
+          command: choco install firefox-nightly --pre --ignore-checksums
+      - run:
+          name: Run addon submissions tests
+          environment:
+            MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -n 1 --reruns 2
+          command: py -3.9 -m pytest tests\devhub\test_addon_submissions.py --driver Firefox --variables dev.json --html=submissions-dev-test-results.html --self-contained-html
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: submissions-dev-test-results.html
+
 workflows:
   commit_workflow:
     when:
@@ -480,3 +510,4 @@ workflows:
       - collections_dev_serial_tests
       - ratings_dev_serial_tests
       - devhub_dev_parallel_tests
+      - addon_submissions_dev_tests

--- a/dev.json
+++ b/dev.json
@@ -126,7 +126,7 @@
   "devhub_submit_addon_distribution_header": "How to Distribute this Version",
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
-  "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",
+  "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons-dev.allizom.org. Note t...f your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_addon_summary_en": "Listed add-on summary set at add-on creation time",
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",

--- a/dev.json
+++ b/dev.json
@@ -126,7 +126,7 @@
   "devhub_submit_addon_distribution_header": "How to Distribute this Version",
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
-  "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons-dev.allizom.org. Note t...f your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",
+  "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons-dev.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_addon_summary_en": "Listed add-on summary set at add-on creation time",
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",


### PR DESCRIPTION
This PR adds the config and variables necessary for running the addon devhub submission tests on AMO -dev. 