### PR TITLE
Update collection description edits

### DIFF
--- a/pages/desktop/frontend/collections.py
+++ b/pages/desktop/frontend/collections.py
@@ -132,6 +132,9 @@ class Collections(Base):
         def set_description(self, value):
             self.find_element(*self._description_input_locator).send_keys(value)
 
+        def clear_description(self):
+            self.find_element(*self._description_input_locator).clear()
+
         @property
         def description_value(self):
             return self.find_element(*self._description_input_locator).text

--- a/tests/frontend/test_collections.py
+++ b/tests/frontend/test_collections.py
@@ -55,6 +55,7 @@ def test_collection_creator_and_modified_date(selenium, base_url, variables, wai
     # making a small edit to trigger a modified date change in the collection
     collections.collection_detail.click_edit_collection_button()
     collections.collection_detail.click_edit_collection_meta()
+    collections.create.clear_description()
     collections.create.set_description(variables['collection_edit_description'])
     collections.create.save_collection()
     # waits for the list of collection stats to be loaded


### PR DESCRIPTION
The collection description has been limited to 280 characters. I've added an option to clear the previous description in a collection before adding new text in order to not reach the character limit. 