### PR TITLE
add versioncheck test and refactor firefox options

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -1,6 +1,9 @@
 {
   "base_url": "https://addons-dev.allizom.org",
 
+  "extensions_update_url": "https://versioncheck-dev.allizom.org/update/VersionCheck.php?reqVersion=%REQ_VERSION%&id=%ITEM_ID%&version=%ITEM_VERSION%&maxAppVersion=%ITEM_MAXAPPVERSION%&status=%ITEM_STATUS%&appID=%APP_ID%&appVersion=%APP_VERSION%&appOS=%APP_OS%&appABI=%APP_ABI%&locale=%APP_LOCALE%&currentAppVersion=%CURRENT_APP_VERSION%&updateType=%UPDATE_TYPE%&compatMode=%COMPATIBILITY_MODE%",
+  "extension_version_updates": "facebook-container",
+
   "search_term": "Flagfox",
 
   "not_found_page_title": "Oops! We can’t find that page",

--- a/pages/desktop/about_addons.py
+++ b/pages/desktop/about_addons.py
@@ -21,6 +21,11 @@ class AboutAddons(Page):
     _installed_addon_name_locator = (By.CSS_SELECTOR, '.addon-name a')
     _installed_addon_author_locator = (By.CSS_SELECTOR, '.addon-detail-row-author a')
     _find_more_addons_button_locator = (By.CLASS_NAME, 'primary')
+    _installed_extension_version_locator = (
+        By.CSS_SELECTOR,
+        '.addon-detail-row-version',
+    )
+    _options_button_locator = (By.CSS_SELECTOR, '.more-options-button')
 
     def wait_for_page_to_load(self):
         self.wait.until(
@@ -118,6 +123,15 @@ class AboutAddons(Page):
         from pages.desktop.frontend.home import Home
 
         return Home(self.driver, self.base_url).wait_for_page_to_load()
+
+    @property
+    def installed_version_number(self):
+        return self.find_element(
+            *self._installed_extension_version_locator
+        ).text.replace('Version\n', '')
+
+    def click_options_button(self):
+        self.find_element(*self._options_button_locator).click()
 
     class AddonCards(Region):
         _theme_image_locator = (By.CLASS_NAME, 'card-heading-image')

--- a/prod.json
+++ b/prod.json
@@ -1,6 +1,8 @@
 {
   "base_url": "https://addons.mozilla.org/",
 
+  "extension_version_updates": "flagfox",
+
   "search_term": "Flagfox",
 
   "fxa_login_page": "accounts.firefox.com",

--- a/stage.json
+++ b/stage.json
@@ -1,6 +1,9 @@
 {
   "base_url": "https://addons.allizom.org",
 
+  "extensions_update_url": "https://versioncheck.allizom.org/update/VersionCheck.php?reqVersion=%REQ_VERSION%&id=%ITEM_ID%&version=%ITEM_VERSION%&maxAppVersion=%ITEM_MAXAPPVERSION%&status=%ITEM_STATUS%&appID=%APP_ID%&appVersion=%APP_VERSION%&appOS=%APP_OS%&appABI=%APP_ABI%&locale=%APP_LOCALE%&currentAppVersion=%CURRENT_APP_VERSION%&updateType=%UPDATE_TYPE%&compatMode=%COMPATIBILITY_MODE%",
+  "extension_version_updates": "devhub-listed-ext-07-27",
+
   "search_term": "Flagfox",
 
   "not_found_page_title": "Oops! We can’t find that page",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def sensitive_url(request, base_url):
 
 
 @pytest.fixture
-def firefox_options(firefox_options, request):
+def firefox_options(firefox_options, base_url, variables):
     """Firefox options.
 
     These options configure firefox to allow for addon installation,
@@ -43,11 +43,9 @@ def firefox_options(firefox_options, request):
     '-headless': Firefox will run headless
 
     """
-    # for prod installation tests, we do not need to set special prefs,
-    # so I've added a custom marker which will allow the Firefox
-    # driver to run a clean profile for prod tests, when necessary
-    marker = request.node.get_closest_marker('firefox_release')
-    if marker:
+    # for prod installation tests, we do not need to set special prefs, so we
+    # separate the browser set-up based on the AMO environments
+    if base_url == 'https://addons.mozilla.org/':
         firefox_options.add_argument('-headless')
         firefox_options.log.level = 'trace'
         firefox_options.set_preference(
@@ -70,6 +68,8 @@ def firefox_options(firefox_options, request):
             'extensions.getAddons.get.url',
             'https://services.addons.allizom.org/api/v4/addons/search/?guid=%IDS%&lang=%LOCALE%',
         )
+        firefox_options.set_preference(
+            'extensions.update.url', variables['extensions_update_url'])
         firefox_options.add_argument('-headless')
         firefox_options.log.level = 'trace'
     return firefox_options

--- a/tests/frontend/test_blog.py
+++ b/tests/frontend/test_blog.py
@@ -169,7 +169,6 @@ def test_addon_card_recommendation_badge_link(base_url, selenium, variables):
             page.driver.switch_to.window(initial_window)
 
 
-@pytest.mark.firefox_release
 @pytest.mark.prod_only
 @pytest.mark.nondestructive
 def test_blog_install_addon(
@@ -204,7 +203,6 @@ def test_blog_install_addon(
         )
 
 
-@pytest.mark.firefox_release
 @pytest.mark.prod_only
 @pytest.mark.nondestructive
 def test_addon_link_in_article_addon_cards(base_url, selenium):
@@ -219,7 +217,6 @@ def test_addon_link_in_article_addon_cards(base_url, selenium):
     assert addon_name == addon_detail.name
 
 
-@pytest.mark.firefox_release
 @pytest.mark.prod_only
 @pytest.mark.nondestructive
 def test_author_link_in_article_addon_cards(base_url, selenium):

--- a/tests/frontend/test_sanity.py
+++ b/tests/frontend/test_sanity.py
@@ -26,7 +26,6 @@ def test_language_tools_landing_page(selenium, base_url, variables):
 
 @pytest.mark.nondestructive
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_install_language_pack(
     selenium, base_url, variables, firefox, firefox_notifications
 ):
@@ -47,7 +46,6 @@ def test_install_language_pack(
 
 @pytest.mark.sanity
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_install_dictionary(
     selenium, base_url, variables, firefox, firefox_notifications
 ):
@@ -68,7 +66,6 @@ def test_install_dictionary(
 
 @pytest.mark.sanity
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_install_extension(
     selenium, base_url, variables, firefox, firefox_notifications
 ):
@@ -87,7 +84,6 @@ def test_install_extension(
 
 @pytest.mark.sanity
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_install_theme(selenium, base_url, variables, firefox, firefox_notifications):
     extension = variables['install_theme']
     selenium.get(f'{base_url}/addon/{extension}')
@@ -103,7 +99,6 @@ def test_install_theme(selenium, base_url, variables, firefox, firefox_notificat
 
 
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 @pytest.mark.skip(reason='Still investigating why this test has started failing recently')
 def test_about_addons_search(selenium, base_url):
     selenium.get('about:addons')
@@ -118,7 +113,6 @@ def test_about_addons_search(selenium, base_url):
 
 
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_about_addons_find_more_addons(selenium, base_url, wait):
     selenium.get('about:addons')
     about_addons = AboutAddons(selenium).wait_for_page_to_load()
@@ -128,7 +122,6 @@ def test_about_addons_find_more_addons(selenium, base_url, wait):
 
 
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_about_addons_addon_cards(selenium, base_url, wait):
     selenium.get('about:addons')
     about_addons = AboutAddons(selenium)
@@ -156,7 +149,6 @@ def test_about_addons_addon_cards(selenium, base_url, wait):
 
 
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_about_addons_addon_cards_author_link(selenium, base_url, wait):
     selenium.get('about:addons')
     about_addons = AboutAddons(selenium)
@@ -173,7 +165,6 @@ def test_about_addons_addon_cards_author_link(selenium, base_url, wait):
 
 
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_about_addons_addon_stats_match_amo(selenium, base_url, wait):
     selenium.get('about:addons')
     about_addons = AboutAddons(selenium)
@@ -194,7 +185,6 @@ def test_about_addons_addon_stats_match_amo(selenium, base_url, wait):
 
 
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_about_addons_install_extension(
     selenium, base_url, wait, firefox, firefox_notifications
 ):
@@ -231,7 +221,6 @@ def test_about_addons_install_extension(
 
 
 @pytest.mark.prod_only
-@pytest.mark.firefox_release
 def test_about_addons_install_theme(
     selenium, base_url, wait, firefox, firefox_notifications
 ):


### PR DESCRIPTION
This PR includes:
- adding a test to verify extension version updates in addons manager for dev, stage and prod
- refactor the `firefox_options` fixture to set up browser prefs based on the `base_url` rather than a `marker`

The test failure is unrelated (the failing test will need to be updated once AMO decides for a badge for the Notable addon group when they show up in the primary hero).