### PR TITLE
Add test for new version autoapproval

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -4,6 +4,8 @@ import hashlib
 import json
 import zipfile
 
+import requests
+
 
 def make_addon(manifest_data):
     """Dynamically create a simple extension with minimal manifest properties"""
@@ -85,3 +87,17 @@ def compare_source_files(file_a, file_b, request):
             f'Source files were not updated successfully: previous_source_from_api_hash = {previous_source_from_api}, '
             f'source_from_api_hash = {source_from_api}'
         )
+
+
+def get_addon_version_string(base_url, addon, auth):
+    """Get the version string of an addon's latest version by using
+    the /addons/versions/ API endpoint"""
+    request = requests.get(
+        url=f'{base_url}/api/v5/addons/addon/{addon}/versions/?filter=all_with_unlisted',
+        headers={'Authorization': f'Session {auth}'},
+    )
+    assert (
+        request.status_code == 200
+    ), f'Actual response was: status code: {request.status_code}, {request.text}'
+    version_string = request.json()['results'][0]['version']
+    return version_string

--- a/dev.json
+++ b/dev.json
@@ -134,6 +134,7 @@
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
   "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
+  "unlisted_new_version_autoapproval": "d32f73ca33d448dcb244",
 
   "duplicate_guid": "@contain-facebook",
   "approved_addon_with_sources": "jswszwpeoc",

--- a/dev.json
+++ b/dev.json
@@ -134,7 +134,7 @@
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
   "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
-  "unlisted_new_version_autoapproval": "d32f73ca33d448dcb244",
+  "unlisted_new_version_autoapproval": "f662ab5044bc446da307",
 
   "duplicate_guid": "@contain-facebook",
   "approved_addon_with_sources": "jswszwpeoc",

--- a/pages/desktop/developers/manage_versions.py
+++ b/pages/desktop/developers/manage_versions.py
@@ -21,7 +21,7 @@ class ManageVersions(Page):
 
     @property
     def version_approval_status(self):
-        return self.find_element(*self._version_approval_status_locator)
+        return self.find_elements(*self._version_approval_status_locator)
 
     def wait_for_version_autoapproval(self, value):
         """Method that verifies if auto-approval occurs within a set time"""
@@ -31,17 +31,17 @@ class ManageVersions(Page):
         while time.time() < timeout_start + 300:
             # refresh the page to check if the status has changed
             self.driver.refresh()
-            if value not in self.version_approval_status.text:
+            if value not in self.version_approval_status[0].text:
                 # wait 30 seconds before we refresh again
                 time.sleep(30)
-            # break the loop of the status changed to the expected value within set time
+            # break the loop if the status changed to the expected value within set time
             else:
                 break
         # if auto-approval took longer than normal, we want to fail the test and capture the final status
         else:
             pytest.fail(
                 f'Autoapproval took longer than normal; '
-                f'Addon final status was "{self.version_approval_status.text}" instead of "{value}"'
+                f'Addon final status was "{self.version_approval_status[0].text}" instead of "{value}"'
             )
 
     def delete_addon(self):

--- a/prod.json
+++ b/prod.json
@@ -49,6 +49,6 @@
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
   "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
-  "unlisted_new_version_autoapproval": "ab2015cc8fa74f47bdb5"
+  "unlisted_new_version_autoapproval": "cc4159b18c48407ba5b8"
 }
 

--- a/prod.json
+++ b/prod.json
@@ -48,6 +48,7 @@
   "listed_addon_summary_en": "Listed add-on summary set at add-on creation time",
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
-  "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer"
+  "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
+  "unlisted_new_version_autoapproval": "ab2015cc8fa74f47bdb5"
 }
 

--- a/stage.json
+++ b/stage.json
@@ -136,5 +136,6 @@
   "listed_addon_summary_en": "Listed add-on summary set at add-on creation time",
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
-  "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer"
+  "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
+  "unlisted_new_version_autoapproval": "59bac570a962431c87b0"
 }

--- a/stage.json
+++ b/stage.json
@@ -137,7 +137,7 @@
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
   "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
-  "unlisted_new_version_autoapproval": "59bac570a962431c87b0",
+  "unlisted_new_version_autoapproval": "2d11928fedca404e81a4",
 
   "duplicate_guid": "@contain-facebook",
   "approved_addon_with_sources": "jswszwpeoc",

--- a/tests/devhub/test_addon_submissions.py
+++ b/tests/devhub/test_addon_submissions.py
@@ -1,7 +1,10 @@
 import pytest
 
 from pages.desktop.developers.devhub_home import DevHubHome
+from pages.desktop.developers.manage_versions import ManageVersions
+from pages.desktop.developers.submit_addon import SubmitAddon
 from scripts import reusables
+from api import api_helpers, payloads
 
 
 @pytest.mark.sanity
@@ -34,10 +37,9 @@ def test_submit_unlisted_addon(selenium, base_url, variables, wait):
     wait.until(lambda _: 'Unlisted-addon-auto' in manage_addons.addon_list[0].name)
 
 
-@pytest.mark.sanity
 @pytest.mark.serial
 @pytest.mark.create_session('submissions_user')
-def test_verify_if_version_is_autoapproved(selenium, base_url, variables, wait):
+def test_verify_first_version_autoapproval(selenium, base_url, variables, wait):
     """This test will wait (for max 5 minutes) until the status of an add-on changes to approved"""
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     my_addons = page.click_my_addons_header_link()
@@ -145,6 +147,45 @@ def test_submit_mixed_addon_versions(selenium, base_url, variables, wait):
     edit_addon = manage_addons.addon_list[0].click_addon_name()
     # verify that the unlisted addon badge is now visible on the edit details page
     assert edit_addon.unlisted_version_tooltip.is_displayed()
+
+
+@pytest.mark.sanity
+@pytest.mark.serial
+def test_verify_new_unlisted_version_autoapproval(selenium, base_url, variables):
+    """Uploads a new version to an existing addon and verifies that is auto-approved"""
+    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    page.devhub_login('developer')
+    addon = variables['unlisted_new_version_autoapproval']
+    # in order to upload a new version, we need to increment on the existing version number
+    # to obtain the current version number, we make an API request that returns the value
+    auth = selenium.get_cookie('sessionid')['value']
+    version_string = api_helpers.get_addon_version_string(base_url, addon, auth)
+    # create a new addon version with the incremented versio number
+    manifest = {
+        **payloads.minimal_manifest,
+        'version': f'{float(version_string) + 1}',
+        'name': 'New version auto-approval',
+    }
+    api_helpers.make_addon(manifest)
+    # go to the unlisted distribution page to submit a new version
+    selenium.get(f'{base_url}/developers/addon/{addon}/versions/submit/')
+    submit_version = SubmitAddon(selenium).wait_for_page_to_load()
+    submit_version.upload_addon('make-addon.zip')
+    # wait for the validation to finish and check if it is successful
+    submit_version.is_validation_successful()
+    assert submit_version.success_validation_message.is_displayed()
+    # on submit source code page, select No as we do not test source code upload here
+    source = submit_version.click_continue_upload_button()
+    source.select_no_to_omit_source()
+    confirmation_page = source.continue_unlisted_submission()
+    assert (
+        variables['unlisted_submission_confirmation']
+        in confirmation_page.submission_confirmation_messages[0].text
+    )
+    # open the manage versions page for the addon and wait for the latest version to be auto-approved
+    selenium.get(f'{base_url}/developers/addon/{addon}/versions')
+    version_status = ManageVersions(selenium).wait_for_page_to_load()
+    version_status.wait_for_version_autoapproval('Approved')
 
 
 @pytest.mark.sanity

--- a/tests/devhub/test_addon_submissions.py
+++ b/tests/devhub/test_addon_submissions.py
@@ -2,9 +2,12 @@ import pytest
 
 from pages.desktop.developers.devhub_home import DevHubHome
 from pages.desktop.developers.manage_versions import ManageVersions
-from pages.desktop.developers.submit_addon import SubmitAddon
+from pages.desktop.developers.submit_addon import (
+    SubmitAddon,
+    SubmissionConfirmationPage,
+)
 from scripts import reusables
-from api import api_helpers, payloads
+from api import api_helpers
 
 
 @pytest.mark.sanity
@@ -162,7 +165,8 @@ def test_verify_new_unlisted_version_autoapproval(selenium, base_url, variables)
     version_string = api_helpers.get_addon_version_string(base_url, addon, auth)
     # create a new addon version with the incremented versio number
     manifest = {
-        **payloads.minimal_manifest,
+        'manifest_version': 2,
+        'theme': {'frame': '#083af0', 'tab_background_text': '#ffffff'},
         'version': f'{float(version_string) + 1}',
         'name': 'New version auto-approval',
     }
@@ -174,10 +178,8 @@ def test_verify_new_unlisted_version_autoapproval(selenium, base_url, variables)
     # wait for the validation to finish and check if it is successful
     submit_version.is_validation_successful()
     assert submit_version.success_validation_message.is_displayed()
-    # on submit source code page, select No as we do not test source code upload here
-    source = submit_version.click_continue_upload_button()
-    source.select_no_to_omit_source()
-    confirmation_page = source.continue_unlisted_submission()
+    submit_version.click_continue()
+    confirmation_page = SubmissionConfirmationPage(selenium)
     assert (
         variables['unlisted_submission_confirmation']
         in confirmation_page.submission_confirmation_messages[0].text


### PR DESCRIPTION
This PR includes:
- create a method that allows to retrieve the version string for an addon's latest version
- create a test that verifies that new unlisted version submissions for an already approved addon are being auto-approved

Note: the failed job is not related to my changes; the failures are caused by AMO -dev being really unstable for the past few weeks so running tests on -dev is a bit unreliable right now; that being said, this shouldn't block this PR because the changes made were tested and the related jobs are passing