### PR TITLE
Remove autoapproval test from sanity suite

### DIFF
--- a/tests/devhub/test_addon_submissions.py
+++ b/tests/devhub/test_addon_submissions.py
@@ -34,7 +34,6 @@ def test_submit_unlisted_addon(selenium, base_url, variables, wait):
     wait.until(lambda _: 'Unlisted-addon-auto' in manage_addons.addon_list[0].name)
 
 
-@pytest.mark.sanity
 @pytest.mark.serial
 @pytest.mark.create_session('submissions_user')
 def test_verify_if_version_is_autoapproved(selenium, base_url, variables, wait):


### PR DESCRIPTION
There have been some changes to autoapproval on prod which makes this autoapproval test not applicable. Until I have a new solution, I'm removing the test from the sanity suite. 