### PR TITLE
Move API tests to run on stage instead of dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
       - store_artifacts:
           path: sanity-serial-test-results.html
 
-  # api addon submission tests covering uploads, edits, authors; the tests are run on -dev to avoid the API throttling
+  # api addon submission tests covering uploads, edits, authors;
   api_submission_tests:
     executor:
       name: win/default
@@ -268,7 +268,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 1 --reruns 2
-          command: py -3.9 -m pytest tests\api --driver Firefox --variables dev.json --html=api_submission_tests.html --self-contained-html
+          command: py -3.9 -m pytest tests\api --driver Firefox --variables stage.json --html=api_submission_tests.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: api_submission_tests.html

--- a/stage.json
+++ b/stage.json
@@ -136,5 +136,41 @@
   "listed_addon_summary_en": "Listed add-on summary set at add-on creation time",
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
-  "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer"
+  "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
+
+  "duplicate_guid": "@contain-facebook",
+  "approved_addon_with_sources": "jswszwpeoc",
+  "api_post_valid_author": 11688279,
+  "api_addon_author_owner": 11688278,
+  "api_post_author_no_display_name": 11688334,
+  "api_post_additional_author": 11685651,
+  "api_post_author_no_dev_agreement": 11688335,
+  "contributions_bad_request_message": "{\"contributions_url\":[\"URL domain must be one of [www.buymeacoffee.com, donate.mozilla.org, flattr.com, github.com, ko-fi.com, liberapay.com, www.micropayment.de, opencollective.com, www.patreon.com, www.paypal.com, paypal.me].\"]}",
+  "image_validation_messages": [
+      "Images must be either PNG or JPG.",
+      "Images must be either PNG or JPG.",
+      "Images cannot be animated.",
+      "Upload a valid image. The file you uploaded was either not an image or a corrupted image.",
+      "Images must be square (same width and height)."
+   ],
+  "name_translations_from_locales_xpi": {
+       "ar": "«غرير الخصوصية»",
+       "de": "German name from _locales",
+       "en-US": "Privacy Badger",
+       "fr": "Privacy Badger",
+       "pl": "Privacy Badger",
+       "pt-BR": "Privacy Badger",
+       "ru": "Privacy Badger",
+       "zh-CN": "隐私獾"
+  },
+  "summary_translations_from_locales_xpi": {
+       "ar": "يتعلم «غرير الخصوصية» تلقائيا أن يحجب المتعقبات الخفية",
+       "de": "German summary from _locales.",
+       "en-US": "Privacy Badger automatically learns to block invisible trackers.",
+       "fr": "Privacy Badger apprend automatiquement à bloquer les traqueurs invisibles.",
+       "pl": "Privacy Badger automatycznie uczy się blokować niewidoczne elementy śledzące.",
+       "pt-BR": "O Privacy Badger aprende automaticamente a bloquear rastreadores invisíveis.",
+       "ru": "Privacy Badger автоматически учится блокировать невидимые трекеры.",
+       "zh-CN": "隐私獾会自动学习去阻止不可见的追踪器。"
+  }
 }

--- a/tests/api/test_addon_uploads.py
+++ b/tests/api/test_addon_uploads.py
@@ -85,7 +85,7 @@ def test_upload_addon_crx_archive(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     uuid = upload.json()['uuid']
     payload = payloads.listed_addon_minimal(uuid)
@@ -130,7 +130,7 @@ def test_upload_addon_unsupported_file_types(base_url, session_auth, file_type):
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     uuid = upload.json()['uuid']
     payload = payloads.listed_addon_minimal(uuid)
@@ -180,7 +180,7 @@ def test_upload_addon_with_broken_archives(base_url, session_auth, file_type):
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     uuid = upload.json()['uuid']
     payload = payloads.listed_addon_minimal(uuid)
@@ -337,7 +337,7 @@ def test_submit_xpi_with_trademark_restricted_user(
     upload.raise_for_status()
     resp = upload.json()
     # sleep to allow the upload  request to be processed
-    time.sleep(3)
+    time.sleep(5)
     uuid = resp['uuid']
     payload = payloads.listed_addon_minimal(uuid)
     create_addon = requests.post(
@@ -391,7 +391,7 @@ def test_submit_addon_with_reserved_guid(base_url, session_auth, guid):
         )
     upload.raise_for_status()
     # sleep to allow the upload  request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     print(resp)
     uuid = resp['uuid']
@@ -437,7 +437,7 @@ def test_upload_extension_with_duplicate_guid(base_url, session_auth, variables)
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     uuid = resp['uuid']
     payload = payloads.listed_addon_minimal(uuid)
@@ -474,7 +474,7 @@ def test_upload_extension_without_name_in_manifest(base_url, session_auth):
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     print(resp)
     uuid = resp['uuid']
@@ -522,7 +522,7 @@ def test_upload_extension_without_summary(base_url, session_auth):
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     print(resp)
     uuid = resp['uuid']
@@ -565,7 +565,7 @@ def test_upload_extension_with_incorrect_version_number(base_url, session_auth):
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     uuid = resp['uuid']
     # we need to inspect the validation results returned by the linter
@@ -620,7 +620,7 @@ def test_upload_extension_with_put_method(base_url, session_auth):
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     print(resp)
     uuid = resp['uuid']
@@ -664,7 +664,7 @@ def test_upload_extension_with_put_guid_mismatch(base_url, session_auth):
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     print(resp)
     uuid = resp['uuid']
@@ -699,7 +699,7 @@ def test_upload_extension_with_put_no_guid_in_manifest(base_url, session_auth):
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     print(resp)
     uuid = resp['uuid']
@@ -742,7 +742,7 @@ def test_upload_extension_with_put_no_guid_in_request(base_url, session_auth):
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     uuid = resp['uuid']
     payload = payloads.listed_addon_minimal(uuid)
@@ -783,7 +783,7 @@ def test_upload_extension_with_put_invalid_guid_format(base_url, session_auth):
         )
     upload.raise_for_status()
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     print(resp)
     uuid = resp['uuid']
@@ -825,7 +825,7 @@ def test_upload_extension_default_locale_has_no_translations(base_url, session_a
             data={'channel': 'listed'},
         )
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     resp = upload.json()
     # get the addon uuid generated after upload
@@ -869,7 +869,7 @@ def test_upload_extension_with_localizations_in_xpi(base_url, session_auth, vari
             data={'channel': 'listed'},
         )
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     resp = upload.json()
     upload.raise_for_status()
     # get the addon uuid generated after upload
@@ -906,7 +906,7 @@ def test_upload_localized_extension_json_overwrite(base_url, session_auth):
             data={'channel': 'listed'},
         )
     # sleep to allow the first request to be processed
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     resp = upload.json()
     # get the addon uuid generated after upload
@@ -955,7 +955,7 @@ def test_upload_addon_with_guid_from_deleted_addon(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     uuid = upload.json()['uuid']
     payload = payloads.listed_addon_minimal(uuid)
@@ -991,7 +991,7 @@ def test_upload_addon_with_guid_from_deleted_addon(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     uuid = upload.json()['uuid']
     payload = payloads.listed_addon_minimal(uuid)
@@ -1022,7 +1022,7 @@ def test_upload_theme(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-        time.sleep(3)
+        time.sleep(5)
         upload.raise_for_status()
         # get the addon uuid generated after upload
         uuid = upload.json()['uuid']
@@ -1056,7 +1056,7 @@ def test_upload_theme_with_wrong_license(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-        time.sleep(3)
+        time.sleep(5)
         upload.raise_for_status()
         # get the addon uuid generated after upload
         uuid = upload.json()['uuid']
@@ -1096,7 +1096,7 @@ def test_upload_language_pack_unauthorized_user(selenium, base_url):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     # get the addon uuid generated after upload
     uuid = upload.json()['uuid']
@@ -1195,7 +1195,7 @@ def test_upload_privileged_addon_with_unauthorized_account(base_url, session_aut
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-        time.sleep(3)
+        time.sleep(5)
         upload.raise_for_status()
         # get the addon uuid generated after upload
         uuid = upload.json()['uuid']
@@ -1226,7 +1226,7 @@ def test_upload_privileged_addon_with_authorized_account(selenium, base_url):
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-        time.sleep(3)
+        time.sleep(5)
         upload.raise_for_status()
         # get the addon uuid generated after upload
         uuid = upload.json()['uuid']
@@ -1270,7 +1270,7 @@ def test_upload_addon_with_reserved_guid_authorized_account(base_url, session_au
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-        time.sleep(3)
+        time.sleep(5)
         upload.raise_for_status()
         # get the addon uuid generated after upload
         uuid = upload.json()['uuid']
@@ -1310,7 +1310,7 @@ def test_upload_addon_with_trademark_name_authorized_account(
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-        time.sleep(3)
+        time.sleep(5)
         upload.raise_for_status()
         uuid = upload.json()['uuid']
         payload = payloads.listed_addon_minimal(uuid)

--- a/tests/api/test_api_versions_edit.py
+++ b/tests/api/test_api_versions_edit.py
@@ -121,7 +121,7 @@ def test_upload_new_listed_version(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     # get the addon uuid generated after upload
     uuid = upload.json()['uuid']
@@ -155,7 +155,7 @@ def test_upload_new_version_with_existing_version_number(base_url, session_auth)
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     # get the addon uuid generated after upload
     uuid = upload.json()['uuid']
@@ -198,7 +198,7 @@ def test_upload_new_unlisted_version_with_put_method(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'unlisted'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     resp = upload.json()
     # verify that the upload was created as unlisted
@@ -231,7 +231,7 @@ def test_upload_new_version_with_different_addon_type(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     # get the addon uuid generated after upload
     uuid = upload.json()['uuid']
@@ -275,7 +275,7 @@ def test_upload_new_version_with_different_guid(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     # get the addon uuid generated after upload
     uuid = upload.json()['uuid']
@@ -315,7 +315,7 @@ def test_upload_new_version_with_sources(base_url, session_auth):
             files={'upload': file},
             data={'channel': 'listed'},
         )
-    time.sleep(3)
+    time.sleep(5)
     upload.raise_for_status()
     # get the addon uuid generated after upload
     uuid = upload.json()['uuid']


### PR DESCRIPTION
Previously, the API submission tests were running on -dev but I'm moving them to stage with a plan to also include them in the -dev regression runs at a later date when -dev becomes more stable (we had some timeout issues there for the pat few weeks). 

I've also increased the wait time between requests slightly because I've notice some addon creation tests failing sometimes because the addon upload request was not fully processed (the API returns 201 early, before the necessary upload validations finish running in the background).