### PR TITLE
Increase autoapproval wait and remove test from sanity

### DIFF
--- a/pages/desktop/developers/manage_versions.py
+++ b/pages/desktop/developers/manage_versions.py
@@ -28,7 +28,7 @@ class ManageVersions(Page):
         timeout_start = time.time()
         # auto-approvals should normally take ~5 minutes;
         # set a loop to verify if approval occurs within this interval
-        while time.time() < timeout_start + 300:
+        while time.time() < timeout_start + 360:
             # refresh the page to check if the status has changed
             self.driver.refresh()
             if value not in self.version_approval_status[0].text:

--- a/tests/frontend/test_home.py
+++ b/tests/frontend/test_home.py
@@ -200,7 +200,6 @@ def test_home_popular_themes_shelf(base_url, selenium):
     assert users_list == sorted(users_list, reverse=True)
 
 
-@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_home_see_more_recommended_themes(base_url, selenium):
     page = Home(selenium, base_url).open().wait_for_page_to_load()


### PR DESCRIPTION
- give auto-approval a bit over 5 minutes to run before exiting the wait loop
- remove recommended themes shelf test from sanity since is no longer part of the homepage (for the moment)