### PR TITLE
Add test for discovery taar recommendations

### DIFF
--- a/prod.json
+++ b/prod.json
@@ -1,5 +1,5 @@
 {
-  "base_url": "https://addons.mozilla.org/",
+  "base_url": "https://addons.mozilla.org",
 
   "extension_version_updates": "flagfox",
 
@@ -49,6 +49,8 @@
   "listed_addon_description_en": "Listed add-on description set at add-on creation time",
   "listed_addon_privacy_policy_en": "Listed add-on privacy policy",
   "listed_addon_reviewer_notes": "TEST ADDON: Reviewer notes set by the developer",
-  "unlisted_new_version_autoapproval": "cc4159b18c48407ba5b8"
+  "unlisted_new_version_autoapproval": "cc4159b18c48407ba5b8",
+
+  "telemetry_client_id": "06ecc8cef773a56ce40baa1ca1237184ea2c6a6a7f0485eda1ea7f4b5c317c65"
 }
 

--- a/stage.json
+++ b/stage.json
@@ -10,6 +10,8 @@
 
   "fxa_login_page": "accounts.firefox.com",
 
+  "telemetry_client_id": "1111111111111111111111111111111111111111111111111111111111111111",
+
   "detail_extension_slug": "ghostery",
   "detail_extension_name": "Ghostery - Privacy Ad Blocker",
   "addon_with_stats": "facebook-container",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def firefox_options(firefox_options, base_url, variables):
     """
     # for prod installation tests, we do not need to set special prefs, so we
     # separate the browser set-up based on the AMO environments
-    if base_url == 'https://addons.mozilla.org/':
+    if base_url == 'https://addons.mozilla.org':
         firefox_options.add_argument('-headless')
         firefox_options.log.level = 'trace'
         firefox_options.set_preference(


### PR DESCRIPTION
This new test verifies that recommendations from addons manager are coming from the TAAR service.  This is an API test only. 