### PR TITLE
Add test for addon distribution page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 1 --reruns 2
-          command: py -3.9 -m pytest tests\frontend\test_ratings.py --driver Firefox --variables stage.json --html=ratings-test-results.html --self-contained-html
+          command: py -3.9 -m pytest tests\frontend\test_ratings.py -m "serial" --driver Firefox --variables stage.json --html=ratings-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: ratings-test-results.html
@@ -148,7 +148,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 4 --reruns 2
-          command: py -3.9 -m pytest tests\devhub\test_devhub_home.py --driver Firefox --variables stage.json --html=devhub-parallel-test-results.html --self-contained-html
+          command: py -3.9 -m pytest tests\devhub -m "not serial and not prod_only" --driver Firefox --variables stage.json --html=devhub-parallel-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: devhub-parallel-test-results.html
@@ -178,7 +178,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 1 --reruns 2
-          command: py -3.9 -m pytest tests\devhub\test_addon_submissions.py --driver Firefox --variables stage.json --html=submissions-test-results.html --self-contained-html
+          command: py -3.9 -m pytest tests\devhub\test_addon_submissions.py -m "serial" --driver Firefox --variables stage.json --html=submissions-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: submissions-test-results.html

--- a/dev.json
+++ b/dev.json
@@ -131,6 +131,11 @@
   "distribution_page_explainer": "Before starting, please read and accept our Firefox Add-on Distribution Agreement as well as our Review Policies and Rules. The Firefox Add-on Distribution Agreement also links to our Privacy Notice which explains how we handle your information.",
   "distribution_user_consent": "I have read and accept this Agreement and the Rules and Policies.",
   "devhub_submit_addon_distribution_header": "How to Distribute this Version",
+  "listed_option_helptext": "Your submission is publicly listed on addons-dev.allizom.org.",
+  "unlisted_option_helptext": "After your submission is signed by Mozilla, you can download the .xpi file from the Developer Hub and distribute it to your audience. Please make sure the add-on manifest’s update_url is provided, as this is the URL where Firefox finds updates for automatic deployment to your users.",
+  "distribution_and_signing_helptext": "You can learn more about these options by reading Add-on Distribution and Signing on Firefox Extension Workshop.",
+  "addon_policies_helptext": "All add-ons must comply with Mozilla’s Add-on Policies and are subject to manual review at any time after submission.",
+
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons-dev.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",

--- a/pages/desktop/developers/submit_addon.py
+++ b/pages/desktop/developers/submit_addon.py
@@ -45,8 +45,25 @@ class SubmitAddon(Page):
     _accept_agreement_button = (By.ID, 'accept-agreement')
     _cancel_agreement_button = (By.CSS_SELECTOR, '.submit-buttons a')
     _dev_accounts_info_link_locator = (By.CSS_SELECTOR, '.addon-submission-process p a')
+
     _listed_option_locator = (By.CSS_SELECTOR, 'input[value="listed"]')
+    _listed_option_helptext_locator = (
+        By.CSS_SELECTOR,
+        "label[for='id_channel_0'] span[class='helptext']",
+    )
     _unlisted_option_locator = (By.CSS_SELECTOR, 'input[value="unlisted"]')
+    _unlisted_option_helptext_locator = (
+        By.CSS_SELECTOR,
+        "label[for='id_channel_1'] span[class='helptext']",
+    )
+    _distribution_and_signing_helptext_locator = (
+        By.CSS_SELECTOR,
+        '.addon-submit-distribute p:nth-of-type(3)',
+    )
+    _addon_policies_helptext_locator = (
+        By.CSS_SELECTOR,
+        '.addon-submit-distribute p:nth-of-type(4)',
+    )
     _change_distribution_link_locator = (By.CSS_SELECTOR, '.addon-submit-distribute a')
     _continue_button_locator = (By.CSS_SELECTOR, '.addon-submission-field button')
     _upload_file_button_locator = (By.CSS_SELECTOR, '.invisible-upload input')
@@ -90,7 +107,7 @@ class SubmitAddon(Page):
     def review_policies_article_link(self):
         return self.find_element(*self._review_policies_link_locator)
 
-    def click_distribution_and_policy_article_link(self, link, text):
+    def click_extension_workshop_article_link(self, link, text):
         """Clicks on the Distribution agreement and the Policies links
         which open an Extension Workshop article page in a new tab"""
         link.click()
@@ -139,11 +156,43 @@ class SubmitAddon(Page):
             )
         )
 
+    @property
+    def listed_option_helptext(self):
+        return self.find_element(*self._listed_option_helptext_locator).text
+
+    @property
+    def unlisted_option_helptext(self):
+        return self.find_element(*self._unlisted_option_helptext_locator)
+
+    @property
+    def update_url_link(self):
+        return self.unlisted_option_helptext.find_element(By.CSS_SELECTOR, 'a')
+
+    @property
+    def listed_option_radiobutton(self):
+        return self.find_element(*self._listed_option_locator)
+
     def select_listed_option(self):
         self.find_element(*self._listed_option_locator).click()
 
     def select_unlisted_option(self):
         self.find_element(*self._unlisted_option_locator).click()
+
+    @property
+    def distribution_and_signing_helptext(self):
+        return self.find_element(*self._distribution_and_signing_helptext_locator)
+
+    @property
+    def distribution_and_signing_link(self):
+        return self.distribution_and_signing_helptext.find_element(By.CSS_SELECTOR, 'a')
+
+    @property
+    def addon_policies_helptext(self):
+        return self.find_element(*self._addon_policies_helptext_locator)
+
+    @property
+    def addon_policies_link(self):
+        return self.addon_policies_helptext.find_element(By.CSS_SELECTOR, 'a')
 
     def change_version_distribution(self):
         """Changes the distribution (listed/unlisted) when submitting a new version"""

--- a/stage.json
+++ b/stage.json
@@ -134,6 +134,10 @@
   "devhub_submit_addon_distribution_header": "How to Distribute this Version",
   "distribution_page_explainer": "Before starting, please read and accept our Firefox Add-on Distribution Agreement as well as our Review Policies and Rules. The Firefox Add-on Distribution Agreement also links to our Privacy Notice which explains how we handle your information.",
   "distribution_user_consent": "I have read and accept this Agreement and the Rules and Policies.",
+  "listed_option_helptext": "Your submission is publicly listed on addons.allizom.org.",
+  "unlisted_option_helptext": "After your submission is signed by Mozilla, you can download the .xpi file from the Developer Hub and distribute it to your audience. Please make sure the add-on manifest’s update_url is provided, as this is the URL where Firefox finds updates for automatic deployment to your users.",
+  "distribution_and_signing_helptext": "You can learn more about these options by reading Add-on Distribution and Signing on Firefox Extension Workshop.",
+  "addon_policies_helptext": "All add-ons must comply with Mozilla’s Add-on Policies and are subject to manual review at any time after submission.",
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",

--- a/tests/devhub/test_devhub_home.py
+++ b/tests/devhub/test_devhub_home.py
@@ -226,68 +226,6 @@ def test_devhub_click_submit_new_theme_button(selenium, base_url, wait):
 
 
 @pytest.mark.nondestructive
-def test_devhub_developer_agreement_page_contents(selenium, base_url, variables, wait):
-    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-    # use an account that hasn't accepted the agreement before
-    page.devhub_login('regular_user')
-    page.wait_for_page_to_load()
-    dist_agreement = page.click_submit_addon_button()
-    assert (
-        variables['devhub_submit_addon_agreement_header']
-        in dist_agreement.distribution_header.text
-    )
-    assert (
-        variables['distribution_page_explainer']
-        in dist_agreement.distribution_page_explainer
-    )
-    assert (
-        'Firefox Add-on Distribution Agreement'
-        in dist_agreement.distribution_agreement_article_link.text
-    )
-    assert (
-        'Review Policies and Rules' in dist_agreement.review_policies_article_link.text
-    )
-    assert variables['distribution_user_consent'] in dist_agreement.user_consent_text
-    wait.until(lambda _: dist_agreement.recaptcha.is_displayed())
-    # clicking on Cancel agreement should redirect to Devhub Homepage
-    dist_agreement.cancel_agreement.click()
-    page = DevHubHome(selenium, base_url).wait_for_page_to_load()
-    assert page.page_logo.is_displayed()
-
-
-@pytest.mark.nondestructive
-def test_devhub_developer_agreement_page_links(selenium, base_url):
-    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-    # use an account that hasn't accepted the agreement before
-    page.devhub_login('regular_user')
-    dist_agreement = page.click_submit_addon_button()
-    # check that the distribution agreement link opens the correct Extension workshop page
-    dist_agreement.click_distribution_and_policy_article_link(
-        dist_agreement.distribution_agreement_article_link,
-        'Firefox Add-on Distribution Agreement',
-    )
-    # check that the review policies link opens the correct Extension workshop page
-    dist_agreement.click_distribution_and_policy_article_link(
-        dist_agreement.review_policies_article_link, 'Add-on Policies'
-    )
-    # verify that the Dev Account info link opens an Extension Workshop article page
-    dist_agreement.click_dev_accounts_info_link()
-
-
-@pytest.mark.nondestructive
-def test_devhub_developer_agreement_checkboxes(selenium, base_url):
-    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-    # use an account that hasn't accepted the agreement before
-    page.devhub_login('regular_user')
-    dist_agreement = page.click_submit_addon_button()
-    dist_agreement.distribution_agreement_checkbox.click()
-    assert dist_agreement.distribution_agreement_checkbox.is_selected()
-    dist_agreement.review_policies_checkbox.click()
-    assert dist_agreement.review_policies_checkbox.is_selected()
-    dist_agreement.click_recaptcha_checkbox()
-
-
-@pytest.mark.nondestructive
 def test_devhub_click_first_theme_button(selenium, base_url, variables):
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     # an account with no add-ons submitted is used


### PR DESCRIPTION
This PR includes:
- restructuring of the developer hub tests (moved all tests that are part of the submission flow into the `test_addon_submissions` module)
- some corrections in the circleci config file
- page objects and test for the addon distribution page