### PR TITLE
Set an addon invisible through devhub

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -141,6 +141,12 @@
   "compatibility_helptext": "Which applications is this version compatible with?",
   "create_theme_subheader": "Create a Theme Version",
   "addon_validation_warning": "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process",
+  "devhub_invisible_addon": "invisible_addon_auto",
+  "visible_status_explainer": "Visible to everyone on https://addons-dev.allizom.org and included in search results and product pages.",
+  "invisible_status_explainer": "Won't be included in search results, and its product page will indicate you disabled it. New version submissions for product won't be accepted in this state.",
+  "hide_addon_confirmation_text": "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates.",
+
+
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons-dev.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",

--- a/pages/desktop/developers/manage_versions.py
+++ b/pages/desktop/developers/manage_versions.py
@@ -8,12 +8,22 @@ from selenium.webdriver.support import expected_conditions as EC
 
 
 class ManageVersions(Page):
+    _addon_name_title_locator = (By.CSS_SELECTOR, 'div[class="section"] header h2')
+    _listing_visibility_section_locator = (By.CSS_SELECTOR, '#edit-addon h3:nth-child(1)')
+    _visible_listing_radio_locator = (By.CSS_SELECTOR, 'input[value="listed"]')
+    _visible_explainer_text_locator = (By.CSS_SELECTOR, '#addon-current-state label:nth-child(1)')
+    _invisible_listing_radio_locator = (By.CSS_SELECTOR, 'input[value="hidden"]')
+    _invisible_explainer_text_locator = (By.CSS_SELECTOR, '#addon-current-state label:nth-of-type(2)')
+    _hide_addon_confirmation_text_locator = (By.CSS_SELECTOR, '#modal-disable p:nth-child(1)')
+    _hide_addon_button_locator = (By.CSS_SELECTOR, '#modal-disable p button')
+    _hide_addon_cancel_link_locator = (By.CSS_SELECTOR, '#modal-disable p a')
     _version_list_locator = (By.ID, 'version-list')
     _version_approval_status_locator = (
         By.CSS_SELECTOR,
         '#version-list .file-status div:nth-child(1)',
     )
     _incomplete_status_locator = (By.CSS_SELECTOR, '.status-incomplete b')
+    _addon_listed_status_locator = (By.CSS_SELECTOR, '.addon-listed-status b')
     _delete_addon_button_locator = (By.CLASS_NAME, 'delete-button.delete-addon')
 
     def wait_for_page_to_load(self):
@@ -21,12 +31,56 @@ class ManageVersions(Page):
         return self
 
     @property
-    def version_approval_status(self):
-        return self.find_elements(*self._version_approval_status_locator)
+    def version_page_title(self):
+        return self.find_element(*self._addon_name_title_locator).text
+
+    @property
+    def listing_visibility_section(self):
+        return self.find_element(*self._listing_visibility_section_locator).text
+
+    def set_addon_visible(self):
+        """Selects the Visible option and checks that the radio button is selected"""
+        el = self.find_element(*self._visible_listing_radio_locator)
+        el.clcik()
+        assert el.is_selected()
+
+    @property
+    def visible_status_explainer(self):
+        return self.find_element(*self._visible_explainer_text_locator).text
+
+    @property
+    def invisible_status_explainer(self):
+        return self.find_element(*self._invisible_explainer_text_locator).text
+
+    def set_addon_invisible(self):
+        """Selects the Invisible option and checks that the radio button is selected"""
+        el = self.find_element(*self._invisible_listing_radio_locator)
+        el.clcik()
+        self.wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, '#modal-disable p:nth-child(1)')))
+
+    def click_hide_addon(self):
+        self.find_element(*self._hide_addon_button_locator).click()
+
+    @property
+    def hide_addon_confirmation_text(self):
+        return self.find_element(*self._hide_addon_confirmation_text_locator).text
+
+    def cancel_hide_addon_process(self):
+        """Cancel the hide addon process and check that the Visible radio button is still selected"""
+        self.find_element(*self._hide_addon_cancel_link_locator).click()
+        assert self.find_element(*self._visible_listing_radio_locator).is_selected()
+
+    @property
+    def addon_listed_status(self):
+        return self.find_element(*self._addon_listed_status_locator).text
 
     @property
     def incomplete_status(self):
         return self.find_element(*self._incomplete_status_locator)
+
+    @property
+    def version_approval_status(self):
+        return self.find_elements(*self._version_approval_status_locator)
 
     def wait_for_version_autoapproval(self, value):
         """Method that verifies if auto-approval occurs within a set time"""

--- a/pages/desktop/developers/manage_versions.py
+++ b/pages/desktop/developers/manage_versions.py
@@ -9,12 +9,24 @@ from selenium.webdriver.support import expected_conditions as EC
 
 class ManageVersions(Page):
     _addon_name_title_locator = (By.CSS_SELECTOR, 'div[class="section"] header h2')
-    _listing_visibility_section_locator = (By.CSS_SELECTOR, '#edit-addon h3:nth-child(1)')
+    _listing_visibility_section_locator = (
+        By.CSS_SELECTOR,
+        '#edit-addon h3:nth-child(1)',
+    )
     _visible_listing_radio_locator = (By.CSS_SELECTOR, 'input[value="listed"]')
-    _visible_explainer_text_locator = (By.CSS_SELECTOR, '#addon-current-state label:nth-child(1)')
+    _visible_explainer_text_locator = (
+        By.CSS_SELECTOR,
+        '#addon-current-state label:nth-child(1)',
+    )
     _invisible_listing_radio_locator = (By.CSS_SELECTOR, 'input[value="hidden"]')
-    _invisible_explainer_text_locator = (By.CSS_SELECTOR, '#addon-current-state label:nth-of-type(2)')
-    _hide_addon_confirmation_text_locator = (By.CSS_SELECTOR, '#modal-disable p:nth-child(1)')
+    _invisible_explainer_text_locator = (
+        By.CSS_SELECTOR,
+        '#addon-current-state label:nth-of-type(2)',
+    )
+    _hide_addon_confirmation_text_locator = (
+        By.CSS_SELECTOR,
+        '#modal-disable p:nth-child(1)',
+    )
     _hide_addon_button_locator = (By.CSS_SELECTOR, '#modal-disable p button')
     _hide_addon_cancel_link_locator = (By.CSS_SELECTOR, '#modal-disable p a')
     _version_list_locator = (By.ID, 'version-list')
@@ -41,7 +53,7 @@ class ManageVersions(Page):
     def set_addon_visible(self):
         """Selects the Visible option and checks that the radio button is selected"""
         el = self.find_element(*self._visible_listing_radio_locator)
-        el.clcik()
+        el.click()
         assert el.is_selected()
 
     @property
@@ -55,8 +67,12 @@ class ManageVersions(Page):
     def set_addon_invisible(self):
         """Selects the Invisible option and checks that the radio button is selected"""
         el = self.find_element(*self._invisible_listing_radio_locator)
-        el.clcik()
-        self.wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, '#modal-disable p:nth-child(1)')))
+        el.click()
+        self.wait.until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '#modal-disable p:nth-child(1)')
+            )
+        )
 
     def click_hide_addon(self):
         self.find_element(*self._hide_addon_button_locator).click()

--- a/stage.json
+++ b/stage.json
@@ -144,6 +144,10 @@
   "compatibility_helptext": "Which applications is this version compatible with?",
   "create_theme_subheader": "Create a Theme Version",
   "addon_validation_warning": "Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process",
+  "devhub_invisible_addon": "invisible_addon_auto",
+  "visible_status_explainer": "Visible to everyone on https://addons.allizom.org and included in search results and product pages.",
+  "invisible_status_explainer": "Won't be included in search results, and its product page will indicate you disabled it. New version submissions for product won't be accepted in this state.",
+  "hide_addon_confirmation_text": "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates.",
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",

--- a/tests/devhub/test_addon_edit.py
+++ b/tests/devhub/test_addon_edit.py
@@ -1,0 +1,38 @@
+from pages.desktop.developers.devhub_home import DevHubHome
+from pages.desktop.developers.manage_versions import ManageVersions
+
+
+def test_set_addon_invisible(selenium, base_url, variables, wait):
+    """Set an addon Invisible and then reset the status to Visible"""
+    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    page.devhub_login('developer')
+    selenium.get(f'{base_url}/developers/addon/invisible_addon_auto/versions')
+    manage_version = ManageVersions(selenium, base_url).wait_for_page_to_load()
+    # check that the Listing visibility section has the necessary information for developers
+    assert (
+        variables['visible_status_explainer'] in manage_version.visible_status_explainer
+    )
+    assert (
+        variables['invisible_status_explainer']
+        in manage_version.invisible_status_explainer
+    )
+    # set the addon Invisible and Cancel the process
+    manage_version.set_addon_invisible()
+    assert (
+        variables['hide_addon_confirmation_text']
+        in manage_version.hide_addon_confirmation_text
+    )
+    manage_version.cancel_hide_addon_process()
+    # set the addon Invisible again and finish the process this time
+    manage_version.set_addon_invisible()
+    manage_version.click_hide_addon()
+    wait.until(
+        lambda _: 'Invisible' in manage_version.addon_listed_status,
+        message=f'Actual addon status was {manage_version.addon_listed_status}',
+    )
+    # set the addon status back to visible
+    manage_version.set_addon_visible()
+    wait.until(
+        lambda _: 'Approved' in manage_version.addon_listed_status,
+        message=f'Actual addon status was {manage_version.addon_listed_status}',
+    )


### PR DESCRIPTION
This PR contains:
- page objects for the Listing visibility section in devhub manage version page
- test for setting an addon invisible/visibile