### PR TITLE
Add test for disabling a version through devhub

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -146,8 +146,8 @@
   "visible_status_explainer": "Visible to everyone on https://addons-dev.allizom.org and included in search results and product pages.",
   "invisible_status_explainer": "Won't be included in search results, and its product page will indicate you disabled it. New version submissions for product won't be accepted in this state.",
   "hide_addon_confirmation_text": "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates.",
-
-
+  "delete_version_helptext": "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on.",
+  "delete_version_warning_text": "Important: Once a version has been deleted, you may not upload a new version with the same version number.",
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons-dev.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",

--- a/pages/desktop/developers/manage_versions.py
+++ b/pages/desktop/developers/manage_versions.py
@@ -29,14 +29,31 @@ class ManageVersions(Page):
     )
     _hide_addon_button_locator = (By.CSS_SELECTOR, '#modal-disable p button')
     _hide_addon_cancel_link_locator = (By.CSS_SELECTOR, '#modal-disable p a')
+
+    _incomplete_status_locator = (By.CSS_SELECTOR, '.status-incomplete b')
+    _addon_listed_status_locator = (By.CSS_SELECTOR, '.addon-listed-status b')
+    _delete_addon_button_locator = (By.CLASS_NAME, 'delete-button.delete-addon')
+
+    # Version List Section
     _version_list_locator = (By.ID, 'version-list')
+    _current_version_status_locator = (
+        By.CSS_SELECTOR,
+        '#current-version-status .file-status > div:nth-child(1)',
+    )
     _version_approval_status_locator = (
         By.CSS_SELECTOR,
         '#version-list .file-status div:nth-child(1)',
     )
-    _incomplete_status_locator = (By.CSS_SELECTOR, '.status-incomplete b')
-    _addon_listed_status_locator = (By.CSS_SELECTOR, '.addon-listed-status b')
-    _delete_addon_button_locator = (By.CLASS_NAME, 'delete-button.delete-addon')
+    _disable_delete_version_button_locator = (By.CSS_SELECTOR, '.version-delete a')
+    _delete_version_help_text_locator = (By.CSS_SELECTOR, '.current-version-warning')
+    _delete_version_warning_locator = (By.CSS_SELECTOR, '.highlight.warning')
+    _delete_version_button_locator = (By.CSS_SELECTOR, '.modal-actions .delete-button')
+    _disable_version_button_locator = (
+        By.CSS_SELECTOR,
+        '.modal-actions .disable-button',
+    )
+    _cancel_disable_version_link_locator = (By.CSS_SELECTOR, '.modal-actions .close')
+    _enable_version_button_locator = (By.CSS_SELECTOR, '.file-status button')
 
     def wait_for_page_to_load(self):
         self.wait.until(EC.visibility_of_element_located(self._version_list_locator))
@@ -95,8 +112,42 @@ class ManageVersions(Page):
         return self.find_element(*self._incomplete_status_locator)
 
     @property
+    def current_version_status(self):
+        return self.find_element(*self._current_version_status_locator).text
+
+    @property
     def version_approval_status(self):
         return self.find_elements(*self._version_approval_status_locator)
+
+    def click_delete_disable_version(self):
+        self.find_element(*self._disable_delete_version_button_locator).click()
+        self.wait.until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '.modal-actions .delete-button')
+            ),
+            message='The Delete/Disable modal was not opened',
+        )
+
+    @property
+    def delete_disable_version_helptext(self):
+        return self.find_element(*self._delete_version_help_text_locator).text
+
+    @property
+    def delete_disable_version_warning(self):
+        return self.find_element(*self._delete_version_warning_locator).text
+
+    def click_delete_version_button(self):
+        self.find_element(*self._delete_version_button_locator).click()
+
+    def click_disable_version_button(self):
+        self.find_element(*self._disable_version_button_locator).click()
+
+    def click_cancel_version_delete_link(self):
+        return self.find_element(*self._cancel_disable_version_link_locator).click()
+
+    def click_enable_version(self):
+        """Allows developers to re-enable a version that was previously disabled"""
+        self.find_element(*self._enable_version_button_locator).click()
 
     def wait_for_version_autoapproval(self, value):
         """Method that verifies if auto-approval occurs within a set time"""

--- a/stage.json
+++ b/stage.json
@@ -149,6 +149,8 @@
   "visible_status_explainer": "Visible to everyone on https://addons.allizom.org and included in search results and product pages.",
   "invisible_status_explainer": "Won't be included in search results, and its product page will indicate you disabled it. New version submissions for product won't be accepted in this state.",
   "hide_addon_confirmation_text": "Hiding your add-on will prevent it from appearing anywhere in our gallery and will stop users from receiving automatic updates.",
+  "delete_version_helptext": "You are about to delete the current version of your add-on. This may cause your add-on status to change, or your listing to lose public visibility, if this is the only public version of your add-on.",
+  "delete_version_warning_text": "Important: Once a version has been deleted, you may not upload a new version with the same version number.",
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons.allizom.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",


### PR DESCRIPTION
This PR includes:
- page objects for the version list Delete/Disable modal
- a test for disabling and re-enabling a version from devhub