### PR TITLE
schek/Add_tests_for_devhub_addon_validate_page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ jobs:
           environment:
             MOZ_HEADLESS: 1
             PYTEST_ADDOPTS: -n 4 --reruns 2
-          command: py -3.9 -m pytest tests\devhub\test_devhub_home.py --driver Firefox --variables dev.json --html=devhub-dev-parallel-test-results.html --self-contained-html
+          command: py -3.9 -m pytest tests\devhub -m "not serial and not prod_only" --driver Firefox --variables dev.json --html=devhub-dev-parallel-test-results.html --self-contained-html
           no_output_timeout: 30m
       - store_artifacts:
           path: devhub-dev-parallel-test-results.html

--- a/dev.json
+++ b/dev.json
@@ -76,7 +76,7 @@
   "notifications_help_text": "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons.",
   "developer_profile": "10641570",
   "theme_artist_profile": "6199839",
-  "developer_and_artist_role": "10640485",
+  "developer_and_artist_role": "10642685",
   "non_developer_user": "10642346",
   "user_abuse_initial_form_header": "Report this user for abuse",
   "user_abuse_form_initial_help_text": "If you think this user is violating Mozilla's Add-on Policies, please report this user to Mozilla.",

--- a/dev.json
+++ b/dev.json
@@ -191,5 +191,11 @@
        "pt-BR": "O Privacy Badger aprende automaticamente a bloquear rastreadores invisíveis.",
        "ru": "Privacy Badger автоматически учится блокировать невидимые трекеры.",
        "zh-CN": "隐私獾会自动学习去阻止不可见的追踪器。"
-  }
+  },
+
+  "addon_validation_message": "Your add-on was validated with no errors or warnings.",
+  "on_this_site_label_message": "On this site. Your submission is publicly listed on addons-dev.allizom.org.",
+  "on_your_own_label_message": "On your own. After your submission is signed by Mozilla, you can download the .xpi file from the Developer Hub and distribute it to your audience. Please make sure the add-on manifest’s update_url is provided, as this is the URL where Firefox finds updates for automatic deployment to your users.",
+  "upload_details_text": "Your add-on should end with .zip, .xpi or .crx",
+  "upload_status": "100% complete"
 }

--- a/pages/desktop/developers/devhub_addon_validate.py
+++ b/pages/desktop/developers/devhub_addon_validate.py
@@ -1,0 +1,94 @@
+import os
+
+from pages.desktop.base import Base
+from selenium.webdriver.common.by import By
+from pathlib import Path
+
+from selenium.webdriver.support import expected_conditions as EC
+
+
+class DevhubAddonValidate(Base):
+    """AMO Developer Hub Validate Add-on Page"""
+
+    URL_TEMPLATE = "developers/addon/validate"
+
+    # Locators
+    _create_addon_form = (By.ID, "create-addon")
+    _addon_on_your_site = (
+        By.CSS_SELECTOR,
+        "#id_channel > div:nth-child(1) > label:nth-child(1)",
+    )
+    _addon_on_your_own = (
+        By.CSS_SELECTOR,
+        "#id_channel > div:nth-child(2) > label:nth-child(1)",
+    )
+    _upload_addon_button = (By.ID, "upload-addon")
+    _firefox_app = (By.CSS_SELECTOR,)
+    _create_addon_paragraph = (By.CSS_SELECTOR, ".create-addon p")
+    _list_addon_label = (By.CSS_SELECTOR, ".list-addon label")
+    _on_this_site_checkbox = (By.CSS_SELECTOR, "#id_channel_0")
+    _on_your_own_text_checkbox = (By.CSS_SELECTOR, "#id_channel_1")
+    _upload_details_text = (By.CSS_SELECTOR, ".upload-details")
+    _upload_status_results = (By.ID, "upload-status-results")
+    _upload_status = (By.ID, "uploadstatus")
+
+    def wait_for_page_to_load(self):
+        self.wait.until(
+            lambda _: self.find_element(*self._create_addon_form).is_displayed()
+        )
+        return self
+
+    def is_validation_approved(self):
+        """Wait for addon validation to complete; if not successful, the test will fail"""
+        self.wait.until(EC.visibility_of_element_located(self._upload_status_results))
+
+    @property
+    def addon_on_your_site(self):
+        return self.find_element(*self._addon_on_your_site)
+
+    @property
+    def addon_on_your_own(self):
+        return self.find_element(*self._addon_on_your_own)
+
+    @property
+    def create_addon_paragraph(self):
+        return self.find_element(*self._create_addon_paragraph)
+
+    @property
+    def list_addon_label(self):
+        return self.find_element(*self._list_addon_label)
+
+    @property
+    def on_this_site_checkbox(self):
+        return self.find_element(*self._on_this_site_checkbox)
+
+    @property
+    def on_your_own_text_checkbox(self):
+        return self.find_element(*self._on_your_own_text_checkbox)
+
+    @property
+    def upload_details_text(self):
+        return self.find_element(*self._upload_details_text)
+
+    @property
+    def upload_details_results(self):
+        return self.find_element(*self._upload_status_results)
+
+    @property
+    def upload_status(self):
+        return self.find_element(*self._upload_status)
+
+    def click_on_this_site_checkbox(self):
+        return self.find_element(*self._on_this_site_checkbox).click()
+
+    def click_on_your_own_text_checkbox(self):
+        return self.find_element(*self._on_your_own_text_checkbox).click()
+
+    def click_upload_addon_button(self):
+        self.find_element(*self._upload_addon_button).click()
+
+    def upload_file(self, addon):
+        # Upload given file on the AMO DevHub Validate Page
+        button = self.find_element(*self._upload_addon_button)
+        archive = Path(f"{os.getcwd()}/sample-addons/{addon}")
+        button.send_keys(str(archive))

--- a/stage.json
+++ b/stage.json
@@ -30,6 +30,7 @@
   "install_warning_message": "This add-on is not actively monitored for security by Mozilla. Make sure you trust it before installing.",
   "addon_version_page_url": "https://addons.allizom.org/en-US/firefox/addon/devhub-listed-ext-07-30/versions/",
   "addon_version_install": "worldwide-radio",
+  "addon_validation_message": "Your add-on was validated with no errors or warnings.",
   "version_page_notice_message": "Be careful with old versions! These versions are displayed for testing and reference purposes.\nYou should always use the latest version of an add-on.",
   "contribute_utm_param": "utm_content=product-page-contribute&utm_medium=referral&utm_source=addons.mozilla.org",
   "contribute_card_summary": "The developer of this extension asks that you help support its continued development by making a small contribution.",
@@ -194,5 +195,9 @@
        "pt-BR": "O Privacy Badger aprende automaticamente a bloquear rastreadores invisíveis.",
        "ru": "Privacy Badger автоматически учится блокировать невидимые трекеры.",
        "zh-CN": "隐私獾会自动学习去阻止不可见的追踪器。"
-  }
+  },
+  "on_this_site_label_message": "On this site. Your submission is publicly listed on addons.allizom.org.",
+  "on_your_own_label_message": "On your own. After your submission is signed by Mozilla, you can download the .xpi file from the Developer Hub and distribute it to your audience. Please make sure the add-on manifest’s update_url is provided, as this is the URL where Firefox finds updates for automatic deployment to your users.",
+  "upload_details_text": "Your add-on should end with .zip, .xpi or .crx",
+  "upload_status": "100% complete"
 }

--- a/stage.json
+++ b/stage.json
@@ -76,7 +76,7 @@
   "notifications_help_text": "Mozilla reserves the right to contact you individually about specific concerns with your hosted add-ons.",
   "developer_profile": "11687230",
   "theme_artist_profile": "6199839",
-  "developer_and_artist_role": "11686381",
+  "developer_and_artist_role": "11688815",
   "non_developer_user": "11686961",
   "user_abuse_initial_form_header": "Report this user for abuse",
   "user_abuse_form_initial_help_text": "If you think this user is violating Mozilla's Add-on Policies, please report this user to Mozilla.",

--- a/tests/devhub/test_addon_validate.py
+++ b/tests/devhub/test_addon_validate.py
@@ -8,12 +8,10 @@ def test_validate_addon_listed(selenium, base_url, variables, wait):
     """Go to Devhub Home page and login as the submissions_user"""
     devhub_home = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     devhub_home.devhub_login("developer")
-
     """Go to Devhub Addon Validate page"""
     devhub_addon_validate = (
         DevhubAddonValidate(selenium, base_url).open().wait_for_page_to_load()
     )
-
     assert (
         variables["on_this_site_label_message"]
         in devhub_addon_validate.addon_on_your_site.text
@@ -28,12 +26,10 @@ def test_validate_addon_listed(selenium, base_url, variables, wait):
     """Upload addon and check if validation is approved"""
     devhub_addon_validate.upload_file("unlisted-addon.zip")
     devhub_addon_validate.is_validation_approved()
-
     assert (
         variables["addon_validation_message"]
         in devhub_addon_validate.upload_details_results.text
     )
-
     assert variables["upload_status"] in devhub_addon_validate.upload_status.text
 
 
@@ -41,12 +37,10 @@ def test_validate_addon_unlisted(selenium, base_url, variables, wait):
     """Go to Devhub Home page and login as the submissions_user"""
     devhub_home = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     devhub_home.devhub_login("developer")
-
     """Go to Devhub Addon Validate page"""
     devhub_addon_validate = (
         DevhubAddonValidate(selenium, base_url).open().wait_for_page_to_load()
     )
-
     assert (
         variables["on_this_site_label_message"]
         in devhub_addon_validate.addon_on_your_site.text
@@ -55,17 +49,13 @@ def test_validate_addon_unlisted(selenium, base_url, variables, wait):
         variables["on_your_own_label_message"]
         in devhub_addon_validate.addon_on_your_own.text
     )
-
     """Click on On Your Own Checkbox"""
     devhub_addon_validate.click_on_your_own_text_checkbox()
     assert devhub_addon_validate.on_your_own_text_checkbox.is_selected()
-
     devhub_addon_validate.upload_file("unlisted-addon.zip")
     devhub_addon_validate.is_validation_approved()
-
     assert (
         variables["addon_validation_message"]
         in devhub_addon_validate.upload_details_results.text
     )
-
     assert variables["upload_status"] in devhub_addon_validate.upload_status.text

--- a/tests/devhub/test_addon_validate.py
+++ b/tests/devhub/test_addon_validate.py
@@ -1,0 +1,71 @@
+import pytest
+
+from pages.desktop.developers.devhub_addon_validate import DevhubAddonValidate
+from pages.desktop.developers.devhub_home import DevHubHome
+
+
+def test_validate_addon_listed(selenium, base_url, variables, wait):
+    """Go to Devhub Home page and login as the submissions_user"""
+    devhub_home = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    devhub_home.devhub_login("developer")
+
+    """Go to Devhub Addon Validate page"""
+    devhub_addon_validate = (
+        DevhubAddonValidate(selenium, base_url).open().wait_for_page_to_load()
+    )
+
+    assert (
+        variables["on_this_site_label_message"]
+        in devhub_addon_validate.addon_on_your_site.text
+    )
+    assert (
+        variables["on_your_own_label_message"]
+        in devhub_addon_validate.addon_on_your_own.text
+    )
+    """Click on On This Site Checkbox"""
+    devhub_addon_validate.click_on_this_site_checkbox()
+    assert devhub_addon_validate.on_this_site_checkbox.is_selected()
+    """Upload addon and check if validation is approved"""
+    devhub_addon_validate.upload_file("unlisted-addon.zip")
+    devhub_addon_validate.is_validation_approved()
+
+    assert (
+        variables["addon_validation_message"]
+        in devhub_addon_validate.upload_details_results.text
+    )
+
+    assert variables["upload_status"] in devhub_addon_validate.upload_status.text
+
+
+def test_validate_addon_unlisted(selenium, base_url, variables, wait):
+    """Go to Devhub Home page and login as the submissions_user"""
+    devhub_home = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    devhub_home.devhub_login("developer")
+
+    """Go to Devhub Addon Validate page"""
+    devhub_addon_validate = (
+        DevhubAddonValidate(selenium, base_url).open().wait_for_page_to_load()
+    )
+
+    assert (
+        variables["on_this_site_label_message"]
+        in devhub_addon_validate.addon_on_your_site.text
+    )
+    assert (
+        variables["on_your_own_label_message"]
+        in devhub_addon_validate.addon_on_your_own.text
+    )
+
+    """Click on On Your Own Checkbox"""
+    devhub_addon_validate.click_on_your_own_text_checkbox()
+    assert devhub_addon_validate.on_your_own_text_checkbox.is_selected()
+
+    devhub_addon_validate.upload_file("unlisted-addon.zip")
+    devhub_addon_validate.is_validation_approved()
+
+    assert (
+        variables["addon_validation_message"]
+        in devhub_addon_validate.upload_details_results.text
+    )
+
+    assert variables["upload_status"] in devhub_addon_validate.upload_status.text


### PR DESCRIPTION
Added page object for: https://addons.allizom.org/en-US/developers/addon/validate
Added test file: test_addon_validate.py with two tests for the happy path scenarios
Modified admin users used in user_serial_tests
Updated config for devhub_dev_parallel_tests to include all devhub tests that are not serial or prod_only