### PR TITLE
Revert "Bump exceptiongroup from 1.1.3 to 1.2.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ colorama==0.4.6
 cryptography==42.0.2
 decorator==5.1.1
 defusedxml==0.7.1
-exceptiongroup==1.2.0
+exceptiongroup==1.1.3
 execnet==1.9.0
 FoxPuppet==1.0.3
 future-fstrings==1.2.0


### PR DESCRIPTION
Reverts mozilla/addons-release-tests#956