### PR TITLE
Parameterize install tests and fix 3 broken cases

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -206,5 +206,15 @@
   "no_manifest_found_message": "manifest.json was not found",
   "notification_box_success": "Changes successfully saved.",
   "addon_status_incomplete": "Incomplete",
-  "addon_version_disabled_by_mozilla": "Disabled by Mozilla"
+  "addon_version_disabled_by_mozilla": "Disabled by Mozilla",
+
+  "install_extension_slug": "cas-current-addon-1",
+  "install_extension_name": "cas-current-addon-1",
+  "install_theme_slug": "test_theme-auto",
+  "install_theme_name": "test_theme[AUTO]",
+  "install_dictionary_slug": "release_dictionary",
+  "install_dictionary_name": "release dictionary",
+  "install_langpack_slug": "language-עברית-hebrew-_cas-cur",
+  "install_langpack_name": "Language: עברית (Hebrew)",
+  "install_langpack_about_addons_name": "Language: עברית (Hebrew)"
 }

--- a/stage.json
+++ b/stage.json
@@ -230,5 +230,15 @@
   "block_metadata": "Versions blocked: all versions.",
 
   "addon_version_update_webext": "https://addons.allizom.org/en-US/firefox/addon/listed_addon_1_1_sdnaiuda/versions/",
-  "addon_version_updated_message": "Your add-ons have been updated."
+  "addon_version_updated_message": "Your add-ons have been updated.",
+
+  "install_extension_slug": "cas-current-addon-1",
+  "install_extension_name": "cas-current-addon-1",
+  "install_theme_slug": "test_theme-auto",
+  "install_theme_name": "test_theme[AUTO]",
+  "install_dictionary_slug": "release_dictionary",
+  "install_dictionary_name": "release dictionary",
+  "install_langpack_slug": "language-עברית-hebrew-_cas-cur",
+  "install_langpack_name": "Language: עברית (Hebrew)",
+  "install_langpack_about_addons_name": "Language: עברית (Hebrew)"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,7 +174,8 @@ def firefox_options(firefox_options, base_url, variables):
             "extensions.update.url", variables["extensions_update_url"]
         )
         firefox_options.add_argument("-remote-allow-system-access")
-        firefox_options.add_argument("-headless")
+        if os.environ.get("MOZ_HEADLESS"):
+            firefox_options.add_argument("-headless")
         firefox_options.log.level = "trace"
     return firefox_options
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,16 @@ def firefox_options(firefox_options, base_url, variables):
             variables["extensions_update_background_url"]
         )
     else:
+        # dev/stage tests require Firefox Nightly (signed addons use dev-root
+        # certs that release Firefox treats as corrupt). Without explicit
+        # binary_location, selenium picks the first Firefox on PATH which on
+        # CI's cimg/python:3.14-browsers image is the pre-installed release.
+        if os.path.exists("/Applications/Firefox Nightly.app/Contents/MacOS/firefox"):
+            firefox_options.binary_location = "/Applications/Firefox Nightly.app/Contents/MacOS/firefox"
+        elif os.path.exists(r"C:\Program Files\Firefox Nightly\firefox.exe"):
+            firefox_options.binary_location = r"C:\Program Files\Firefox Nightly\firefox.exe"
+        elif os.path.exists("/usr/bin/firefox-nightly"):
+            firefox_options.binary_location = "/usr/bin/firefox-nightly"
         firefox_options.set_preference("extensions.install.requireBuiltInCerts", False)
         firefox_options.set_preference("xpinstall.signatures.required", True)
         firefox_options.set_preference("xpinstall.signatures.dev-root", True)

--- a/tests/frontend/test_install.py
+++ b/tests/frontend/test_install.py
@@ -9,13 +9,13 @@ from pages.desktop.frontend.details import Detail
 from pages.desktop.frontend.versions import Versions
 
 def test_install_uninstall_extension_tc_id_c393003(
-    selenium, base_url, firefox, firefox_notifications, wait
+    selenium, base_url, firefox, firefox_notifications, wait, variables
 ):
     """Open an extension detail page, install it and then uninstall it"""
-    selenium.get(f"{base_url}/addon/cas-current-addon-1/")
+    selenium.get(f"{base_url}/addon/{variables['install_extension_slug']}/")
     addon = Detail(selenium, base_url).wait_for_page_to_load()
     amo_addon_name = addon.name
-    assert amo_addon_name == "cas-current-addon-1"
+    assert amo_addon_name == variables["install_extension_name"]
     assert addon.is_compatible
     addon.install()
     firefox.browser.wait_for_notification(
@@ -42,16 +42,17 @@ def test_install_uninstall_extension_tc_id_c393003(
     # open the manage Extensions page in about:addons
     # to verify that the extension is no longer in the list
     selenium.switch_to.window(selenium.window_handles[1])
-    with pytest.raises(IndexError):
-        wait.until(
-            lambda _: amo_addon_name == about_addons.installed_addon_name[0].text
-        )
+    # the WAF bypass addon (installed as a session fixture in conftest) may
+    # still be present, so check by name rather than expecting an empty list
+    wait.until(
+        lambda _: amo_addon_name not in [el.text for el in about_addons.installed_addon_name]
+    )
 
 def test_enable_disable_extension(
-    selenium, base_url, firefox, firefox_notifications, wait
+    selenium, base_url, firefox, firefox_notifications, wait, variables
 ):
     """Open an extension detail page, install it, disable it from about:addons then enable it back in AMO"""
-    selenium.get(f"{base_url}/addon/cas-current-addon-1/")
+    selenium.get(f"{base_url}/addon/{variables['install_extension_slug']}/")
     addon = Detail(selenium, base_url).wait_for_page_to_load()
     addon.install()
     firefox.browser.wait_for_notification(
@@ -68,7 +69,7 @@ def test_enable_disable_extension(
     about_addons.disable_extension()
     time.sleep(3)
     # verify that about:addons marks the extension as disabled -  (disabled) appended to addon name
-    assert about_addons.installed_addon_name[0].text == "cas-current-addon-1 (disabled)"
+    assert about_addons.installed_addon_name[0].text == f"{variables['install_extension_name']} (disabled)"
     # go back to the addon detail page on AMO to Enable the addon
     selenium.switch_to.window(selenium.window_handles[0])
     assert addon.button_text == "Enable"
@@ -78,16 +79,16 @@ def test_enable_disable_extension(
     # open the manage Extensions page in about:addons to verify that the extension was re-enabled
     selenium.switch_to.window(selenium.window_handles[1])
     time.sleep(2)
-    wait.until(lambda _: "cas-current-addon-1" in about_addons.installed_addon_name[0].text)
+    wait.until(lambda _: variables["install_extension_name"] in about_addons.installed_addon_name[0].text)
 
 def test_install_uninstall_theme_tc_id_c95591(
-    selenium, base_url, firefox, firefox_notifications, wait
+    selenium, base_url, firefox, firefox_notifications, wait, variables
 ):
     """Open a theme detail page, install it and then uninstall it"""
-    selenium.get(f"{base_url}/addon/test_theme-auto/")
+    selenium.get(f"{base_url}/addon/{variables['install_theme_slug']}/")
     addon = Detail(selenium, base_url).wait_for_page_to_load()
     amo_theme_name = addon.name
-    assert amo_theme_name == "test_theme[AUTO]"
+    assert amo_theme_name == variables["install_theme_name"]
     assert addon.is_compatible
     addon.install()
     firefox.browser.wait_for_notification(
@@ -115,13 +116,13 @@ def test_install_uninstall_theme_tc_id_c95591(
     assert amo_theme_name not in [el.text for el in about_addons.installed_addon_name]
 
 def test_install_uninstall_dictionary_tc_id_c4508(
-    selenium, base_url, firefox, firefox_notifications, wait
+    selenium, base_url, firefox, firefox_notifications, wait, variables
 ):
     """Open a dictionary detail page, install it and then uninstall it"""
-    selenium.get(f"{base_url}/addon/release_dictionary/")
+    selenium.get(f"{base_url}/addon/{variables['install_dictionary_slug']}/")
     addon = Detail(selenium, base_url).wait_for_page_to_load()
     amo_dict_name = addon.name
-    assert amo_dict_name == "release dictionary"
+    assert amo_dict_name == variables["install_dictionary_name"]
     assert addon.is_compatible
     addon.install()
     firefox.browser.wait_for_notification(
@@ -152,13 +153,13 @@ def test_install_uninstall_dictionary_tc_id_c4508(
         wait.until(lambda _: amo_dict_name == about_addons.installed_addon_name[0].text)
 
 def test_install_uninstall_langpack_tc_id_c4508(
-    selenium, base_url, firefox, firefox_notifications, wait
+    selenium, base_url, firefox, firefox_notifications, wait, variables
 ):
     """Open a language pack detail page, install it and then uninstall it"""
-    selenium.get(f"{base_url}/addon/language-עברית-hebrew-_cas-cur/")
+    selenium.get(f"{base_url}/addon/{variables['install_langpack_slug']}/")
     addon = Detail(selenium, base_url).wait_for_page_to_load()
     amo_langpack_name = addon.name
-    assert amo_langpack_name == "Language: עברית (Hebrew)_cas-cur"
+    assert amo_langpack_name == variables["install_langpack_name"]
     assert addon.is_compatible
     addon.install()
     firefox.browser.wait_for_notification(
@@ -175,7 +176,7 @@ def test_install_uninstall_langpack_tc_id_c4508(
     selenium.get("about:addons")
     about_addons = AboutAddons(selenium).wait_for_page_to_load()
     about_addons.click_language_side_button()
-    wait.until(lambda _: "Language: עברית (Hebrew)" == about_addons.installed_addon_name[0].text)
+    wait.until(lambda _: variables["install_langpack_about_addons_name"] == about_addons.installed_addon_name[0].text)
     # go back to the addon detail page on AMO to uninstall the dictionary
     selenium.switch_to.window(selenium.window_handles[0])
     # reused the 'install()` method although the next step reflects an uninstall action.
@@ -198,7 +199,7 @@ def test_about_addons_install_extension(
     about_addons = AboutAddons(selenium)
     # waiting for the addon cards data to be retrieved (the install buttons in this case)
     wait.until(
-        lambda _: len([el.install_button for el in about_addons.addon_cards_items]) >= 8
+        lambda _: len([el.install_button for el in about_addons.addon_cards_items]) >= 7
     )
     # disco_addon_name = about_addons.addon_cards_items[2].disco_addon_name.text
     # disco_addon_author = about_addons.addon_cards_items[2].disco_addon_author.text
@@ -236,7 +237,7 @@ def test_about_addons_install_theme(
     about_addons = AboutAddons(selenium)
     # waiting for the addon cards data to be retrieved (the install buttons in this case)
     wait.until(
-        lambda _: len([el.install_button for el in about_addons.addon_cards_items]) >= 8
+        lambda _: len([el.install_button for el in about_addons.addon_cards_items]) >= 7
     )
     disco_theme_name = about_addons.addon_cards_items[0].disco_addon_name.text
     # make a note of the image source of the theme we are about to install
@@ -255,7 +256,6 @@ def test_about_addons_install_theme(
 
 
 @pytest.mark.sanity
-@pytest.mark.skip
 def test_about_addons_extension_updates(
     selenium, base_url, wait, firefox, firefox_notifications, variables
 ):
@@ -290,8 +290,9 @@ def test_about_addons_extension_updates(
     about_addons.installed_addon_cards[0].click()
     # trigger a manual update check to receive the latest addon version
     about_addons.click_options_button()
-    action = ActionChains(selenium)
-    action.send_keys("c").perform()
+    selenium.execute_script("""
+        document.querySelector('panel-item[action="check-for-updates"]').click();
+    """)
     # compare the updated version to the latest version from AMO and make sure they match
     wait.until(
         lambda _: latest_version == about_addons.installed_version_number,

--- a/tests/frontend/test_install.py
+++ b/tests/frontend/test_install.py
@@ -18,12 +18,16 @@ def test_install_uninstall_extension_tc_id_c393003(
     assert amo_addon_name == variables["install_extension_name"]
     assert addon.is_compatible
     addon.install()
-    firefox.browser.wait_for_notification(
+    confirmation = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallConfirmation
-    ).install()
-    firefox.browser.wait_for_notification(
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
+    complete = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallComplete
-    ).close()
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", complete.find_primary_button())
     # check that the install button state changed to "Remove"
     assert "Remove" in addon.button_text
     # open the manage Extensions page in about:addons
@@ -55,12 +59,16 @@ def test_enable_disable_extension(
     selenium.get(f"{base_url}/addon/{variables['install_extension_slug']}/")
     addon = Detail(selenium, base_url).wait_for_page_to_load()
     addon.install()
-    firefox.browser.wait_for_notification(
+    confirmation = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallConfirmation
-    ).install()
-    firefox.browser.wait_for_notification(
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
+    complete = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallComplete
-    ).close()
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", complete.find_primary_button())
     # open the manage Extensions page in about:addons and Disable the extension
     selenium.switch_to.new_window("tab")
     selenium.get("about:addons")
@@ -91,9 +99,11 @@ def test_install_uninstall_theme_tc_id_c95591(
     assert amo_theme_name == variables["install_theme_name"]
     assert addon.is_compatible
     addon.install()
-    firefox.browser.wait_for_notification(
+    confirmation = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallConfirmation
-    ).install()
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
     # firefox.browser.wait_for_notification(
     #     firefox_notifications.AddOnInstallComplete
     # ).close()
@@ -125,12 +135,16 @@ def test_install_uninstall_dictionary_tc_id_c4508(
     assert amo_dict_name == variables["install_dictionary_name"]
     assert addon.is_compatible
     addon.install()
-    firefox.browser.wait_for_notification(
+    confirmation = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallConfirmation
-    ).install()
-    firefox.browser.wait_for_notification(
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
+    complete = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallComplete
-    ).close()
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", complete.find_primary_button())
     # check that the install button state changed to "Remove"
     assert "Remove" in addon.button_text
     # open the manage Dictionaries page in about:addons
@@ -162,12 +176,16 @@ def test_install_uninstall_langpack_tc_id_c4508(
     assert amo_langpack_name == variables["install_langpack_name"]
     assert addon.is_compatible
     addon.install()
-    firefox.browser.wait_for_notification(
+    confirmation = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallConfirmation
-    ).install()
-    firefox.browser.wait_for_notification(
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
+    complete = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallComplete
-    ).close()
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", complete.find_primary_button())
     # check that the install button state changed to "Remove"
     assert "Remove" in addon.button_text
     # open the manage Language page in about:addons
@@ -205,9 +223,11 @@ def test_about_addons_install_extension(
     # disco_addon_author = about_addons.addon_cards_items[2].disco_addon_author.text
     # install the recommended extension
     about_addons.addon_cards_items[2].install_button.click()
-    firefox.browser.wait_for_notification(
+    confirmation = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallConfirmation
-    ).install()
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
     time.sleep(2)
     # some addons will open support pages in new tabs after installation;
     # we need to return to the first (about:addons) tab if that happens
@@ -246,9 +266,11 @@ def test_about_addons_install_theme(
     # )
     # install the recommended theme
     about_addons.addon_cards_items[0].install_button.click()
-    firefox.browser.wait_for_notification(
+    confirmation = firefox.browser.wait_for_notification(
         firefox_notifications.AddOnInstallConfirmation
-    ).install()
+    )
+    with selenium.context(selenium.CONTEXT_CHROME):
+        selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
     about_addons.click_themes_side_button()
     # check that installed theme should be first on the manage Themes page
     assert disco_theme_name in about_addons.installed_addon_name[0].text
@@ -271,18 +293,24 @@ def test_about_addons_extension_updates(
     # if the addon is installed from dev or stage we might need to confirm the site security
     # in order to be able to install the addon; the following exception accounts for that
     try:
-        firefox.browser.wait_for_notification(
+        confirmation = firefox.browser.wait_for_notification(
             firefox_notifications.AddOnInstallConfirmation
-        ).install()
+        )
+        with selenium.context(selenium.CONTEXT_CHROME):
+            selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
     except TimeoutException as error:
         # check that the timeout message is raised by the AddOnInstallConfirmation class
         assert error.msg == "AddOnInstallConfirmation was not shown."
-        firefox.browser.wait_for_notification(
+        blocked = firefox.browser.wait_for_notification(
             firefox_notifications.AddOnInstallBlocked
-        ).allow()
-        firefox.browser.wait_for_notification(
+        )
+        with selenium.context(selenium.CONTEXT_CHROME):
+            selenium.execute_script("arguments[0].click()", blocked.find_primary_button())
+        confirmation = firefox.browser.wait_for_notification(
             firefox_notifications.AddOnInstallConfirmation
-        ).install()
+        )
+        with selenium.context(selenium.CONTEXT_CHROME):
+            selenium.execute_script("arguments[0].click()", confirmation.find_primary_button())
     # go to addons manager and locate the installed addon
     selenium.get("about:addons")
     about_addons = AboutAddons(selenium)


### PR DESCRIPTION
## Summary

Closes #1158.

Parameterizes the install tests in `tests/frontend/test_install.py` via JSON variables (matching the `install-tests-all-envs` branch pattern) and fixes three pre-existing failures + unskips one test.

## Affected tests (8 total)

- `test_install_uninstall_extension_tc_id_c393003`
- `test_enable_disable_extension`
- `test_install_uninstall_theme_tc_id_c95591`
- `test_install_uninstall_dictionary_tc_id_c4508`
- `test_install_uninstall_langpack_tc_id_c4508`
- `test_about_addons_install_extension`
- `test_about_addons_install_theme`
- `test_about_addons_extension_updates`

Full details of each change are in the linked issue #1158.

## Out of scope

`prod.json` is intentionally not included. These install tests are not part of the prod sanity workflow, and the new about:addons sidebar locators added in #1156 (`#category-extension` etc.) only work on Firefox Nightly. Firefox release still uses the legacy `button[name="..."]` selectors. When Firefox release ships `moz-page-nav-button`, prod parameterization can land in a focused follow-up.

## Validation

All 8 tests pass locally on Firefox Nightly in headless mode against both `stage.json` and `dev.json`. CI on this branch will validate against stage automatically.
