### PR TITLE
Restore restrictedDomains pref for FxA login bypass

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,10 +162,17 @@ def firefox_options(firefox_options, base_url, variables):
         firefox_options.set_preference("extensions.webapi.testing", True)
         firefox_options.set_preference("ui.popup.disable_autohide", True)
         firefox_options.set_preference("devtools.console.stdout.content", True)
+        # Clear the WebExtensions restricted-domain list so the waf_bypass_addon
+        # can attach its `webRequest` listener to Mozilla domains that are
+        # restricted by default. Without this, stage runs hit the FxA captcha
+        # on `accounts.firefox.com` because the addon's listener is silently
+        # skipped on restricted domains.
+        firefox_options.set_preference("extensions.webextensions.restrictedDomains", "")
         firefox_options.set_preference(
             "extensions.getAddons.discovery.api_url",
             variables["extensions_getAddons_discovery_api_url"],
         )
+        
         firefox_options.set_preference(
             "extensions.getAddons.get.url",
             variables["extensions_getAddons_get_url"],


### PR DESCRIPTION
…dev/stage

The waf_bypass_addon (introduced in PR #1144) injects an `fxa-ci` header on FxA login requests to bypass Fastly bot detection. Its webRequest listener is gated by Firefox's `extensions.webextensions.restrictedDomains` pref — Mozilla domains like accounts.firefox.com and addons.mozilla.org are on that list by default, and webextensions can't attach listeners to restricted domains.

PR #1144 (commit 3c7191db, 2026-05-05) addressed this by clearing the restrictedDomains list for dev/stage runs:

    firefox_options.set_preference(
        "extensions.webextensions.restrictedDomains", ""
    )

PR #1156 (commit 6ab2faa, "Schek webext/first tests") accidentally removed that line during a refactor while keeping the 6-line comment that explains why it should be there. The orphaned comment now describes behavior that no longer exists.

Result: stage @pytest.mark.login tests started failing on FxA captcha because the WAF bypass addon's listener was silently skipped on FxA prod (accounts.firefox.com, restricted). Dev runs were unaffected because they hit FxA stage at accounts.stage.mozaws.net, which is not on the restricted list.

This commit restores the missing pref-setting line in the dev/stage else-branch of the firefox_options fixture, matching the original PR #1144 layout. The comment now matches the code again.

Verified locally:
- test_user_profile_write_review against stage.json now bypasses FxA captcha and reaches the logged-in page (previously failed immediately)
- Same test against dev.json still passes (regression check; the pref-clearing is a no-op for dev since FxA stage was never restricted)

Prod is intentionally left alone in this PR. The prod branch of firefox_options never had the pref-clearing line, and adding it there is a deliberate-scope-change tracked separately.