### PR TITLE
Add restrictedDomains pref for prod FxA bypass

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,12 @@ def firefox_options(firefox_options, base_url, variables):
         firefox_options.add_argument("-foreground")
         firefox_options.add_argument("-remote-allow-system-access")
         firefox_options.log.level = "trace"
+        # Clear the WebExtensions restricted-domain list so the waf_bypass_addon
+        # can attach its `webRequest` listener to Mozilla domains that are
+        # restricted by default. Without this, prod runs hit the FxA captcha
+        # on `accounts.firefox.com` because the addon's listener is silently
+        # skipped on restricted domains.
+        firefox_options.set_preference("extensions.webextensions.restrictedDomains", "")
         firefox_options.set_preference(
             "extensions.getAddons.discovery.api_url",
             variables["extensions_getAddons_discovery_api_url"],


### PR DESCRIPTION
Mirrors PR #1166 for the prod branch of the firefox_options fixture.

The waf_bypass_addon (introduced in PR #1144) injects an `fxa-ci` header on FxA login requests to bypass Fastly bot detection. Its `webRequest` listener is gated by Firefox's `extensions.webextensions.restrictedDomains` pref — Mozilla domains like `accounts.firefox.com` and `addons.mozilla.org` are on that list by default, and webextensions cannot attach listeners to restricted domains.

PR #1166 restored the pref-clearing line in the dev/stage `else` branch (it had been accidentally removed in PR #1156). The prod `if` branch never had the line, so prod sanity tests still failed at the FxA captcha on `accounts.firefox.com` after #1166 landed.

This commit adds the same 6-line block to the prod branch. With it in place, the waf_bypass_addon's `webRequest` listener fires on `accounts.firefox.com` for prod runs too, the `fxa-ci` header is injected, and FxA recognizes the test traffic, skipping the captcha.

Verified empirically against AMO prod via a throwaway CI experiment branch (`test-prod-fxa-bypass-ci`) where the `when:` schedule gate and `hold` approval job were temporarily removed from `scheduled_prod_sanity_run` so the workflow would fire on push. Results:

- `sanity_serial_tests`: all tests passed (no login failures)
- `sanity_parallel_tests`: 4 failures, 122 passed, 14 skipped, 1 xfailed, 8 reruns - none of the failures are login-related. They are the documented pre-existing baseline failures (listed-flow drift, etc.).

Local verification: stage, dev, and prod `test_user_profile_write_review` all clear the FxA login step. No regression to dev or stage paths.

Note: enabling header injection on `accounts.firefox.com` for prod expands the WAF bypass scope beyond what PR #1144 originally established. The header value still has to be configured via `FXA_CI_HEADER` env var (currently set per-job in CircleCI), so this change does not by itself authenticate any traffic - it only allows the existing bypass mechanism to operate on prod's FxA endpoint.

Closes #1167