### PR TITLE
Update conftest in order to bypass Fastly on each environment from th…

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -1,4 +1,5 @@
 {
+  "FXA_CI_HEADER": "FXA_CI_HEADER_DEV",
   "base_url": "https://addons-dev.allizom.org",
 
   "extensions_update_url": "https://versioncheck.addons-dev.allizom.org/update/VersionCheck.php?reqVersion=%REQ_VERSION%&id=%ITEM_ID%&version=%ITEM_VERSION%&maxAppVersion=%ITEM_MAXAPPVERSION%&status=%ITEM_STATUS%&appID=%APP_ID%&appVersion=%APP_VERSION%&appOS=%APP_OS%&appABI=%APP_ABI%&locale=%APP_LOCALE%&currentAppVersion=%CURRENT_APP_VERSION%&updateType=%UPDATE_TYPE%&compatMode=%COMPATIBILITY_MODE%",

--- a/prod.json
+++ b/prod.json
@@ -1,4 +1,5 @@
 {
+  "FXA_CI_HEADER": "FXA_CI_HEADER",
   "base_url": "https://addons.mozilla.org",
 
   "extensions_getAddons_discovery_api_url": "https://services.addons.mozilla.org/api/v4/discovery/?lang=%LOCALE%&edition=%DISTRIBUTION%",

--- a/regular_user.txt
+++ b/regular_user.txt
@@ -1,1 +1,0 @@
-6r3z2incmeoeuhkssype49spwmmj0kpf

--- a/stage.json
+++ b/stage.json
@@ -1,4 +1,5 @@
 {
+  "FXA_CI_HEADER": "FXA_CI_HEADER",
   "base_url": "https://addons.allizom.org",
 
   "extensions_update_url": "https://versioncheck.addons.allizom.org/update/VersionCheck.php?reqVersion=%REQ_VERSION%&id=%ITEM_ID%&version=%ITEM_VERSION%&maxAppVersion=%ITEM_MAXAPPVERSION%&status=%ITEM_STATUS%&appID=%APP_ID%&appVersion=%APP_VERSION%&appOS=%APP_OS%&appABI=%APP_ABI%&locale=%APP_LOCALE%&currentAppVersion=%CURRENT_APP_VERSION%&updateType=%UPDATE_TYPE%&compatMode=%COMPATIBILITY_MODE%",

--- a/submissions_user.txt
+++ b/submissions_user.txt
@@ -1,1 +1,0 @@
-ptkrlxrz31vct813nq4d53kssxmvfzkv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,8 @@ from pages.desktop.developers.devhub_home import DevHubHome
 DESKTOP = (1920, 1080)
 
 @pytest.fixture(scope="session")
-def waf_bypass_addon(tmp_path_factory):
-    header_value = os.environ.get("FXA_CI_HEADER_DEV", "")
+def waf_bypass_addon(tmp_path_factory, variables):
+    header_value = os.environ.get(variables["FXA_CI_HEADER"], "")
 
     addon_dir = tmp_path_factory.mktemp("waf_bypass_addon")
 


### PR DESCRIPTION
Modifications made:

- Included variables in method waf_bypass_addon.
- Updated line: header_value = os.environ.get("FXA_CI_HEADER_DEV", "")
- Now it takes from json files the name of the environment variable that's in Circle CI depending on the environment used
- Added in the json files the value.
