### PR TITLE
Update footer tests for the new Firefox footer (#1160) on frontend side

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -480,10 +480,11 @@ class Header(Region):
 class Footer(Region):
     _root_locator = (By.CSS_SELECTOR, ".Footer-wrapper")
     _footer_amo_links_locator = (By.CSS_SELECTOR, ".Footer-amo-links")
-    _footer_browsers_links_locator = (By.CSS_SELECTOR, ".Footer-browsers-links")
-    _footer_products_links_locator = (By.CSS_SELECTOR, ".Footer-product-links")
+    _footer_build_links_locator = (By.CSS_SELECTOR, ".Footer-build-links")
+    _footer_download_links_locator = (By.CSS_SELECTOR, ".Footer-download-links")
     _footer_mozilla_link_locator = (By.CSS_SELECTOR, ".Footer-mozilla-link")
-    _footer_social_locator = (By.CSS_SELECTOR, ".Footer-links-social")
+    _footer_follow_links_locator = (By.CSS_SELECTOR, ".Footer-follow-links")
+    _footer_community_links_locator = (By.CSS_SELECTOR, ".Footer-community-links")
     _footer_links_locator = (By.CSS_SELECTOR, ".Footer-links li a")
     _footer_legal_locator = (By.CSS_SELECTOR, ".Footer-legal-links ")
     _footer_copyright_links_locator = (By.CSS_SELECTOR, ".Footer-copyright a")
@@ -499,19 +500,19 @@ class Footer(Region):
         return element.find_elements(*self._footer_links_locator)
 
     @property
-    def browsers_links(self):
+    def build_links(self):
         self.wait.until(
-            EC.visibility_of_element_located(self._footer_browsers_links_locator)
+            EC.visibility_of_element_located(self._footer_build_links_locator)
         )
-        element = self.find_element(*self._footer_browsers_links_locator)
+        element = self.find_element(*self._footer_build_links_locator)
         return element.find_elements(*self._footer_links_locator)
 
     @property
-    def products_links(self):
+    def download_links(self):
         self.wait.until(
-            EC.visibility_of_element_located(self._footer_products_links_locator)
+            EC.visibility_of_element_located(self._footer_download_links_locator)
         )
-        element = self.find_element(*self._footer_products_links_locator)
+        element = self.find_element(*self._footer_download_links_locator)
         return element.find_elements(*self._footer_links_locator)
 
     @property
@@ -522,10 +523,16 @@ class Footer(Region):
         return self.find_element(*self._footer_mozilla_link_locator)
 
     @property
-    def social_links(self):
-        self.wait.until(EC.visibility_of_element_located(self._footer_social_locator))
-        element = self.find_element(*self._footer_social_locator)
-        return element.find_elements(By.CSS_SELECTOR, "li a")
+    def follow_links(self):
+        self.wait.until(EC.visibility_of_element_located(self._footer_follow_links_locator))
+        element = self.find_element(*self._footer_follow_links_locator)
+        return element.find_elements(*self._footer_links_locator)
+
+    @property
+    def community_links(self):
+        self.wait.until(EC.visibility_of_element_located(self._footer_community_links_locator))
+        element = self.find_element(*self._footer_community_links_locator)
+        return element.find_elements(*self._footer_links_locator)
 
     @property
     def legal_links(self):

--- a/tests/frontend/test_home.py
+++ b/tests/frontend/test_home.py
@@ -114,7 +114,7 @@ def test_primary_hero_tc_id_c95105(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.fail
+@pytest.mark.xfail
 def test_secondary_hero_message(base_url, selenium, variables):
     """Test covering the homepage secondary hero"""
     page = Home(selenium, base_url).open().wait_for_page_to_load()
@@ -285,7 +285,6 @@ def test_theme_categories_shelf_tc_id_c95105(base_url, selenium, count, category
 # Tests covering the homepage footer
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-@pytest.mark.prod_only
 def test_mozilla_footer_link_tc_id_c95105(base_url, selenium):
     """Verifies the mozilla link from the footer"""
     page = Home(selenium, base_url).open().wait_for_page_to_load()
@@ -341,25 +340,23 @@ def test_addons_footer_links_tc_id_c95105(base_url, selenium, count, link):
     "count, link",
     enumerate(
         [
-            # ["en-US/?redirect_source=mozilla-org", "a[class='download-link c-button-download-thanks-link mzp-c-button mzp-t-product mzp-t-xl']"],
-            ["en-US/browsers/mobile/", "a[href='/ro/browsers/mobile/android/']"],
-            ["en-US/browsers/enterprise/", "#primary-download-button"],
+            ["channel/desktop/#nightly", ".fl-logo-fx"],
+            ["channel/desktop/#beta", ".fl-logo-fx"],
+            ["browsers/enterprise/", ".fl-logo-fx"],
         ]
     ),
     ids=[
-        # "Firefox Desktop",
-        "Firefox Mobile",
-        "Firefox Enterprise",
+        "Nightly",
+        "Beta",
+        "Enterprise",
     ],
 )
 @pytest.mark.nondestructive
 @pytest.mark.sanity
-@pytest.mark.skip
-def test_browsers_footer_links_tc_id_c95105(base_url, selenium, count, link):
-    """Verifies the browsers footer links"""
+def test_latest_builds_footer_links_tc_id_c95105(base_url, selenium, count, link):
+    """Verifies the links from the Latest Builds footer column, including Enterprise"""
     page = Home(selenium, base_url).open().wait_for_page_to_load()
-    page.footer.browsers_links[count].click()
-    time.sleep(5)
+    page.footer.build_links[count].click()
     page.wait_for_current_url(link[0])
     page.wait.until(
         EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
@@ -371,28 +368,32 @@ def test_browsers_footer_links_tc_id_c95105(base_url, selenium, count, link):
     "count, link",
     enumerate(
         [
-            # ["/?utm_content=footer-link&", "a[class='download-link c-button-download-thanks-link mzp-c-button mzp-t-product mzp-t-xl']"],
-            ["products/vpn/", ".c-sub-navigation-title"],
-            ["relay.firefox.com/", "img[alt='Firefox Relay Premium']"],
-            ["monitor.mozilla", "img[alt='Mozilla Monitor']"],
-            ["getpocket.com", ".logo"],
+            ["thanks/", ".fl-logo-fx"],
+            ["download/windows/", ".fl-logo-fx"],
+            ["download/mac/", ".fl-logo-fx"],
+            ["download/ios/", ".fl-logo-fx"],
+            ["download/android/", ".fl-logo-fx"],
+            ["download/linux/", ".fl-logo-fx"],
+            ["download/all/", ".fl-logo-fx"],
         ]
     ),
     ids=[
-        # "Browsers",
-        "VPN",
-        "Relay",
-        "Monitor",
-        "Pocket",
+        # "Download",
+        "Download Firefox",
+        "Windows",
+        "macOS",
+        "iOS",
+        "Android",
+        "Linux",
+        "All",
     ],
 )
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-@pytest.mark.skip
-def test_products_footer_links_tc_id_c95105(base_url, selenium, count, link):
+def test_download_footer_links_tc_id_c95105(base_url, selenium, count, link):
+    """Verifies the links from the Download footer column"""
     page = Home(selenium, base_url).open().wait_for_page_to_load()
-    page.footer.products_links[count].click()
-    time.sleep(2)
+    page.footer.download_links[count].click()
     page.wait_for_current_url(link[0])
     page.wait.until(
         EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
@@ -404,25 +405,52 @@ def test_products_footer_links_tc_id_c95105(base_url, selenium, count, link):
     "count, link",
     enumerate(
         [
-            "x.com",
-            "instagram.com",
-            "youtube.com",
+            "instagram.com/firefox",
+            "youtube.com/user/firefoxchannel",
+            "tiktok.com/@firefox",
+            "bsky.app/profile/firefox.com",
+            "youtube.com/@firefox/podcasts",
         ]
     ),
     ids=[
-        "Firefox on Twitter",
-        "Firefox on Instagram",
-        "Firefox on YouTube",
+        "Instagram",
+        "YouTube",
+        "TikTok",
+        "BlueSky",
+        "Podcast",
     ],
 )
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-@pytest.mark.skip(reason="This will either be updated or replaced by new test/tests")
-def test_social_footer_links_tc_id_c95105(base_url, selenium, count, link):
-    """Test that verifies the social links from the footer section"""
+def test_follow_footer_links_tc_id_c95105(base_url, selenium, count, link):
+    """Verifies the destination URLs of the Follow footer column links"""
     page = Home(selenium, base_url).open().wait_for_page_to_load()
-    page.footer.social_links[count].click()
-    page.wait_for_current_url(link)
+    actual_href = page.footer.follow_links[count].get_attribute("href")
+    assert link in actual_href, f"Expected '{link}' in href, got '{actual_href}'"
+
+
+@pytest.mark.parametrize(
+    "count, link",
+    enumerate(
+        [
+            "connect.mozilla.org/",
+            "mozilla.org/contribute/",
+            "firefox.com/en-US/channel/desktop/developer/",
+        ]
+    ),
+    ids=[
+        "Community",
+        "Contribute",
+        "Developer",
+    ],
+)
+@pytest.mark.sanity
+@pytest.mark.nondestructive
+def test_community_footer_links_tc_id_c95105(base_url, selenium, count, link):
+    """Verifies the destination URLs of the Community footer column links"""
+    page = Home(selenium, base_url).open().wait_for_page_to_load()
+    actual_href = page.footer.community_links[count].get_attribute("href")
+    assert link in actual_href, f"Expected '{link}' in href, got '{actual_href}'"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The Mozilla footer redesign (rolled out per mozilla/addons#15925) restructured the AMO footer into new columns: Download, Latest Builds, Follow, and Community. Three previously-skipped frontend footer tests had no path forward against the new structure, and the redesign introduced one entirely new column with no test coverage.

Page object (pages/desktop/base.py - Footer Region):
- Rename `_footer_browsers_links_locator` -> `_footer_build_links_locator` with CSS class `.Footer-build-links`, and property `browsers_links` -> `build_links`. The new column hosts Nightly, Beta, and Enterprise.
- Rename `_footer_products_links_locator` -> `_footer_download_links_locator` with CSS class `.Footer-download-links`, and property `products_links` -> `download_links`. The new column hosts Firefox installers for Windows, macOS, iOS, Android, Linux, and All.
- Rename `_footer_social_locator` -> `_footer_follow_links_locator` with CSS class `.Footer-follow-links`, and property `social_links` -> `follow_links`. The new column hosts Instagram, YouTube, TikTok, BlueSky, and the Firefox Podcast. Switched the inner selector from a custom `"li a"` to the shared `_footer_links_locator` for symmetry with the other columns.
- Add `_footer_community_links_locator` (`.Footer-community-links`) and a new `community_links` property for the new Community column (Community forum, Contribute, Developer channel).

Tests (tests/frontend/test_home.py):
- Repurpose `test_browsers_footer_links_tc_id_c95105` -> `test_latest_builds_footer_links_tc_id_c95105`. 3 parametrized entries for Nightly, Beta, and Enterprise. Drops `@pytest.mark.skip`. Drops the redundant `time.sleep(5)` that paddled around the old Firefox.com load timing. Uses `.fl-logo-fx` as the landing element selector across all three (the modern Firefox header is consistent across firefox.com).
- Repurpose `test_products_footer_links_tc_id_c95105` -> `test_download_footer_links_tc_id_c95105`. 7 parametrized entries for the Download column (Download Firefox + 6 platforms). Drops `skip`, drops `time.sleep(2)`. Uses `.fl-logo-fx` consistently.
- Repurpose `test_social_footer_links_tc_id_c95105` -> `test_follow_footer_links_tc_id_c95105`. 5 parametrized entries. Drops `skip`. Switched the test body from click-and-navigate to an href-only check; we don't want to navigate to Instagram / TikTok / BlueSky in CI because their bot detection is aggressive and could fail intermittently or flag the CI IP range. The AMO-side concern - "does the footer point to the correct URL?" - is fully validated by reading the `href` attribute.
- Add new `test_community_footer_links_tc_id_c95105`. 3 parametrized entries for Community, Contribute, and Developer. Uses the same href-only pattern as Follow because each destination is a different Mozilla property (connect.mozilla.org, mozilla.org, firefox.com) and per-destination landing selectors would triple maintenance.
- Drop `@pytest.mark.prod_only` from `test_mozilla_footer_link_tc_id_c95105` so it runs on dev and stage commit_workflow too. The Mozilla wordmark link target is identical across environments; restricting it to prod only delayed regression detection to once-a-week.
- Drive-by: fix `@pytest.mark.fail` typo on `test_secondary_hero_message` (line 117). Almost certainly a typo for `@pytest.mark.xfail`; `fail` is not a built-in pytest marker and was silently ignored.

Marker coverage after this commit:
- All 8 frontend footer tests now have `@pytest.mark.sanity` + `@pytest.mark.nondestructive` and no `skip` or `prod_only`. They run on stage commit_workflow, dev scheduled, and prod sanity.

Devhub footer tests (tests/devhub/test_devhub_home.py) are out of scope for this PR. Tracked as a follow-up: 11 footer tests there currently lack `@pytest.mark.sanity` so they only run on stage. Will be addressed in a separate PR after a locator audit against the new devhub footer.

Verified locally: 33 parametrized sub-tests across 8 footer tests pass headless against stage, dev, and prod (~1:35-1:45 each).

Closes #1160