### PR TITLE
Update devhub footer tests for the new Firefox footer (#1176)

### DIFF
--- a/pages/desktop/developers/devhub_home.py
+++ b/pages/desktop/developers/devhub_home.py
@@ -63,8 +63,6 @@ class DevHubHome(Base):
     )
     _get_involved_image_locator = (By.CLASS_NAME, "DevHub-content-image--get-involved")
     _footer_language_picker_locator = (By.ID, "language")
-    _footer_products_section_locator = (By.CSS_SELECTOR, ".Footer-products-links")
-    _footer_links_locator = (By.CSS_SELECTOR, ".Footer-links li a")
 
     # elements visible only to logged in users
     _sign_out_link_locator = (
@@ -324,12 +322,6 @@ class DevHubHome(Base):
     def footer_language_picker(self, value):
         select = Select(self.find_element(*self._footer_language_picker_locator))
         select.select_by_visible_text(value)
-
-    @property
-    def products_links(self):
-        self.wait_for_element_to_be_displayed(self._footer_products_section_locator)
-        element = self.find_element(*self._footer_products_section_locator)
-        return element.find_elements(*self._footer_links_locator)
 
     class MyAddonsList(Region):
         _my_addon_icon_locator = (By.CSS_SELECTOR, ".DevHub-MyAddons-item-icon")

--- a/prod.json
+++ b/prod.json
@@ -52,6 +52,8 @@
   "devhub_content_summary": "Sign in to the Developer Hub to submit or manage extensions and themes",
   "devhub_get_involved_header": "Get involved",
   "devhub_get_involved_summary": "Connect with thousands of developers and discover more ways you can contribute to the extension ecosystem.",
+  "devhub_newsletter_header": "Extensions Developers Newsletter",
+  "devhub_newsletter_info_text": "Stay up-to-date on news and events for Firefox extension developers.",
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons.mozilla.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",

--- a/tests/devhub/test_devhub_home.py
+++ b/tests/devhub/test_devhub_home.py
@@ -475,6 +475,7 @@ def test_devhub_resources_participate(selenium, base_url, variables):
     ],
 )
 @pytest.mark.nondestructive
+@pytest.mark.sanity
 def test_page_connect_footer_more_links(selenium, base_url, count, link):
     """Ensures that all "More" links in the footer under
     the "Connect" section lead to the correct pages,
@@ -486,6 +487,7 @@ def test_page_connect_footer_more_links(selenium, base_url, count, link):
 
 
 @pytest.mark.nondestructive
+@pytest.mark.sanity
 def test_connect_newsletter_section(selenium, base_url, variables):
     """Verifies the content and functionality of the newsletter signup
     section in the footer, ensuring that the privacy notice link works
@@ -532,6 +534,7 @@ def test_verify_newsletter_signup_confirmation(selenium, base_url, variables, wa
 
 
 @pytest.mark.nondestructive
+@pytest.mark.sanity
 def test_devhub_mozilla_footer_link(base_url, selenium):
     """Verifies that clicking on the "Mozilla" link in
     the DevHub footer redirects the user to the Mozilla homepage."""
@@ -568,6 +571,7 @@ def test_devhub_mozilla_footer_link(base_url, selenium):
     ],
 )
 @pytest.mark.nondestructive
+@pytest.mark.sanity
 def test_devhub_addons_footer_links(base_url, selenium, count, link):
     """Ensures that the links under the "Add-ons" section
     in the DevHub footer lead to the correct pages,
@@ -581,94 +585,116 @@ def test_devhub_addons_footer_links(base_url, selenium, count, link):
     "count, link",
     enumerate(
         [
-            "https://www.firefox.com/en-US/?redirect_source=mozilla-org&utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link",
-            "en-US/mobile/",
-            "en-US/browsers/enterprise/",
+            ["#nightly", ".fl-logo-fx"],
+            ["#beta", ".fl-logo-fx"],
+            ["browsers/enterprise/", ".fl-logo-fx"],
         ]
     ),
     ids=[
-        "DevHub Footer - Browsers section -  Desktop",
-        "DevHub Footer - Browsers section -  Mobile",
-        "DevHub Footer - Browsers section -  Enterprise",
+        "Nightly",
+        "Beta",
+        "Enterprise",
     ],
 )
 @pytest.mark.nondestructive
-@pytest.mark.skip(reason="Needs update or add new tests scenarios - footer is changed")
-def test_devhub_browsers_footer_links(base_url, selenium, count, link):
-    """Verifies that the links under the "Browsers" section
-    in the DevHub footer lead to the correct pages
-    for Firefox Desktop, Mobile, and Enterprise."""
-    if "addons-dev" in base_url:
-        pytest.skip(
-            "Footer-browsers-links section is not present on the dev devhub footer "
-            "redesign (replaced by Download/Latest Builds/Firefox for Business)"
-        )
+@pytest.mark.sanity
+def test_devhub_latest_builds_footer_links(base_url, selenium, count, link):
+    """Verifies the links from the Latest Builds footer column, including Enterprise."""
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-    page.footer.browsers_links[count].click()
-    time.sleep(5)
-    page.wait_for_current_url(link)
+    page.footer.build_links[count].click()
+    page.wait_for_current_url(link[0])
+    page.wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
+        message=f'The chosen element "{link[1]}" could not be loaded on the "{link[0]}" webpage',
+    )
 
 
 @pytest.mark.parametrize(
     "count, link",
     enumerate(
         [
-            "https://www.firefox.com/en-US/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link",
-            "products/vpn/",
-            "relay.firefox.com/",
-            "monitor.mozilla",
-            "getpocket.com",
+            ["thanks/", ".fl-logo-fx"],
+            ["download/windows/", ".fl-logo-fx"],
+            ["download/mac/", ".fl-logo-fx"],
+            ["download/ios/", ".fl-logo-fx"],
+            ["download/android/", ".fl-logo-fx"],
+            ["download/linux/", ".fl-logo-fx"],
+            ["download/all/", ".fl-logo-fx"],
         ]
     ),
     ids=[
-        "DevHub Footer - Products section -  Browsers",
-        "DevHub Footer - Products section -  VPN",
-        "DevHub Footer - Products section -  Relay",
-        "DevHub Footer - Products section -  Monitor",
-        "DevHub Footer - Products section -  Pocket",
+        "Download Firefox",
+        "Windows",
+        "macOS",
+        "iOS",
+        "Android",
+        "Linux",
+        "All",
     ],
 )
 @pytest.mark.nondestructive
-@pytest.mark.skip(reason="Needs to be updated pr new scenarios added")
-def test_devhub_products_footer_links(base_url, selenium, count, link):
-    """Ensures that the links under the "Products" section
-    in the DevHub footer lead to the correct pages for
-    Firefox, VPN, Relay, Monitor, and Pocket."""
-    if "addons-dev" in base_url:
-        pytest.skip(
-            "Footer-products-links section is not present on the dev devhub footer "
-            "redesign"
-        )
+@pytest.mark.sanity
+def test_devhub_download_footer_links(base_url, selenium, count, link):
+    """Verifies the links from the Download footer column."""
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-    page.products_links[count].click()
-    page.wait_for_current_url(link)
+    page.footer.download_links[count].click()
+    page.wait_for_current_url(link[0])
+    page.wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, link[1])),
+        message=f'The chosen element "{link[1]}" could not be loaded on the "{link[0]}" webpage',
+    )
 
 
+@pytest.mark.parametrize(
+    "count, link",
+    enumerate(
+        [
+            "instagram.com/firefox",
+            "youtube.com/user/firefoxchannel",
+            "tiktok.com/@firefox",
+            "bsky.app/profile/firefox.com",
+            "youtube.com/@firefox/podcasts",
+        ]
+    ),
+    ids=[
+        "Instagram",
+        "YouTube",
+        "TikTok",
+        "BlueSky",
+        "Podcast",
+    ],
+)
 @pytest.mark.nondestructive
-@pytest.mark.skip(reason="Needs to be updated pr new scenarios added")
-def test_devhub_social_footer_links(base_url, selenium):
-    """Verifies that the social media links in the DevHub footer
-    direct users to the correct social media pages."""
-    # The dev footer redesign replaced the "Social" section (.Footer-links-social)
-    # with a "Follow" section (.Footer-follow-links) containing a different set of
-    # links. Stage still has the legacy Social section, but Twitter/X was dropped
-    # in favor of Bluesky. Each env tests its own current list.
-    if "addons-dev" in base_url:
-        expected_links = ["instagram.com", "youtube.com", "tiktok.com", "bsky.app"]
-        section_selector = ".Footer-follow-links"
-    else:
-        expected_links = ["bsky.app", "instagram.com", "youtube.com"]
-        section_selector = ".Footer-links-social"
+@pytest.mark.sanity
+def test_devhub_follow_footer_links(base_url, selenium, count, link):
+    """Verifies the destination URLs of the Follow footer column links."""
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-    section = page.footer.find_element(By.CSS_SELECTOR, section_selector)
-    links = section.find_elements(By.CSS_SELECTOR, "li a")
-    for count, expected in enumerate(expected_links):
-        links[count].click()
-        page.wait_for_current_url(expected)
-        selenium.back()
-        # re-fetch links after navigating back since the DOM was rebuilt
-        section = page.footer.find_element(By.CSS_SELECTOR, section_selector)
-        links = section.find_elements(By.CSS_SELECTOR, "li a")
+    actual_href = page.footer.follow_links[count].get_attribute("href")
+    assert link in actual_href, f"Expected '{link}' in href, got '{actual_href}'"
+
+
+@pytest.mark.parametrize(
+    "count, link",
+    enumerate(
+        [
+            "connect.mozilla.org/",
+            "mozilla.org/contribute/",
+            "firefox.com/en-US/channel/desktop/developer/",
+        ]
+    ),
+    ids=[
+        "Community",
+        "Contribute",
+        "Developer",
+    ],
+)
+@pytest.mark.nondestructive
+@pytest.mark.sanity
+def test_devhub_community_footer_links(base_url, selenium, count, link):
+    """Verifies the destination URLs of the Community footer column links."""
+    page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
+    actual_href = page.footer.community_links[count].get_attribute("href")
+    assert link in actual_href, f"Expected '{link}' in href, got '{actual_href}'"
 
 
 @pytest.mark.parametrize(
@@ -687,6 +713,7 @@ def test_devhub_social_footer_links(base_url, selenium):
     ],
 )
 @pytest.mark.nondestructive
+@pytest.mark.sanity
 def test_devhub_legal_footer_links(base_url, selenium, count, link):
     """Ensures that the legal links in the DevHub footer
     direct users to the correct legal and policy pages."""
@@ -713,6 +740,7 @@ def test_devhub_legal_footer_links(base_url, selenium, count, link):
     ],
 )
 @pytest.mark.nondestructive
+@pytest.mark.sanity
 def test_change_devhub_language(base_url, selenium, language, locale, translation):
     """Verifies that changing the language in the DevHub footer
     correctly updates the locale and displays the translated page,
@@ -737,6 +765,7 @@ def test_change_devhub_language(base_url, selenium, language, locale, translatio
     ],
 )
 @pytest.mark.nondestructive
+@pytest.mark.sanity
 def test_devhub_footer_copyright_message(base_url, selenium, count, link, wait):
     """Ensures that the copyright message in the DevHub footer
     is displayed correctly and that the linked pages


### PR DESCRIPTION
Mirrors the frontend footer redesign work in #1160 for the devhub home page. The Mozilla footer redesign restructured the AMO footer into new columns: Download, Latest Builds, Follow, and Community. The devhub footer now shares the redesigned Footer region in pages/desktop/base.py which #1160 already updated, so no locator changes are needed there.

Tests (tests/devhub/test_devhub_home.py):
- Repurpose test_devhub_browsers_footer_links -> test_devhub_latest_builds_footer_links. 3 parametrized entries for Nightly, Beta, and Enterprise. Drops @pytest.mark.skip and the "addons-dev" runtime skip. Drops the redundant time.sleep(5) that paddled around the old Firefox.com load timing. Uses .fl-logo-fx as the landing element. URL substrings are fragment-only (#nightly, #beta) to sidestep firefox.com's Google Analytics linker (?_gl=...) insertion under Selenium.
- Repurpose test_devhub_products_footer_links -> test_devhub_download_footer_links. 7 parametrized entries for Download Firefox + Windows, macOS, iOS, Android, Linux, and All. Drops skip. Uses .fl-logo-fx consistently.
- Repurpose test_devhub_social_footer_links -> test_devhub_follow_footer_links. 5 parametrized entries (Instagram, YouTube, TikTok, BlueSky, Podcast). Drops skip. Switched from click-and-navigate to an href-only check; we don't want to navigate to Instagram / TikTok / BlueSky in CI because their bot detection is aggressive and could fail intermittently or flag the CI IP range.
- Add new test_devhub_community_footer_links. 3 parametrized entries for Community, Contribute, and Developer. Uses the same href-only pattern as Follow because each destination is a different Mozilla property and per-destination landing selectors would triple maintenance.
- Add @pytest.mark.sanity to 11 footer/connect/language tests (mozilla, addons, latest_builds, download, follow, community, legal, copyright, connect more, connect newsletter, and change_devhub_language), subject to verifying they pass on prod first.

Page object (pages/desktop/developers/devhub_home.py):
- Remove the local _footer_products_section_locator, _footer_links_locator, and products_links property. These duplicated (and stale) the shared Footer region's download_links. Tests now route through page.footer.download_links.

Config (prod.json):
- Restore devhub_newsletter_header and devhub_newsletter_info_text keys so test_connect_newsletter_section can carry the sanity marker across all 3 envs. Values match dev.json and stage.json; user confirmed the newsletter section is visually identical on prod.

Resources footer tests (documentation, tools, promote, join_addon_review, participate) are out of scope. The Resources area is present but login-gated; tests 1/5 rely on the UI FxA login flow that hits an email-verification-code wall in Selenium, and tests 2/3/4 depend on a fresh developer session cookie. Tracked as #1180.

Verified locally headless (MOZ_HEADLESS=1, --driver Firefox):
- dev: 41 passed, 4 skipped
- stage: 41 passed, 4 skipped
- prod: 41 passed, 1 skipped

Closes #1176