### PR TITLE
Refactor devhub Resources footer tests to use login marker (#1180)

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -141,8 +141,7 @@
     "/promote-your-add-ons-with-the-get-the-add-on-button/",
     "extensionworkshop.allizom.org/documentation/publish/recommended-extensions/"
   ],
-  "devhub_resources_review_addons_text": "Volunteer reviewers help keep add-ons safe and reliable to use. They enjoy great perks too!",
-  "devhub_resources_write_some_code_text": "Help make add-ons better by contributing your coding skills.",
+  "devhub_resources_review_addons_text": "Help make add-ons better by contributing your coding skills.",
   "devhub_resources_participate_text": "You don't need coding skills to help keep Firefox the most customizable browser available!",
   "devhub_submit_addon_agreement_header": "Add-on Distribution Agreement",
   "distribution_page_explainer": "Before starting, please read and accept our Firefox Add-on Distribution Agreement, Review Policies and Rules and our Frequently Asked Questions. The Firefox Add-on Distribution Agreement also links to our Privacy Notice which explains how we handle your information.",

--- a/pages/desktop/developers/devhub_home.py
+++ b/pages/desktop/developers/devhub_home.py
@@ -646,18 +646,6 @@ class ResourcesFooter(Region):
         By.CSS_SELECTOR,
         ".DevHub-Footer-sections:nth-of-type(2) .DevHub-Footer-section:nth-of-type(1) a",
     )
-    _write_code_section_header_locator = (
-        By.CSS_SELECTOR,
-        ".DevHub-Footer-sections:nth-of-type(2) .DevHub-Footer-section:nth-of-type(2) h4",
-    )
-    _write_code_info_text_locator = (
-        By.CSS_SELECTOR,
-        ".DevHub-Footer-sections:nth-of-type(2) .DevHub-Footer-section:nth-of-type(2) p",
-    )
-    _write_code_link_locator = (
-        By.CSS_SELECTOR,
-        ".DevHub-Footer-sections:nth-of-type(2) .DevHub-Footer-section:nth-of-type(2) a",
-    )
     _participate_section_header_locator = (
         By.CSS_SELECTOR,
         ".DevHub-Footer-sections:nth-of-type(2) .DevHub-Footer-section:nth-of-type(2) h4",
@@ -728,23 +716,6 @@ class ResourcesFooter(Region):
 
     def click_join_addon_review_link(self):
         self.find_element(*self._addon_review_link_locator).click()
-
-    @property
-    def write_code_section_header(self):
-        self.wait.until(
-            EC.visibility_of_element_located(self._write_code_section_header_locator)
-        )
-        return self.find_element(*self._write_code_section_header_locator).text
-
-    @property
-    def write_code_section_info_text(self):
-        self.wait.until(
-            EC.visibility_of_element_located(self._write_code_info_text_locator)
-        )
-        return self.find_element(*self._write_code_info_text_locator).text
-
-    def click_write_code_section_link(self):
-        self.find_element(*self._write_code_link_locator).click()
 
     @property
     def participate_section_header(self):

--- a/prod.json
+++ b/prod.json
@@ -54,6 +54,21 @@
   "devhub_get_involved_summary": "Connect with thousands of developers and discover more ways you can contribute to the extension ecosystem.",
   "devhub_newsletter_header": "Extensions Developers Newsletter",
   "devhub_newsletter_info_text": "Stay up-to-date on news and events for Firefox extension developers.",
+  "devhub_resources_doc_links": [
+    "/Mozilla/Add-ons/WebExtensions",
+    "extensionworkshop.com/extension-basics/",
+    "extensionworkshop.com/documentation/themes/"
+  ],
+  "devhub_resources_tools_links": [
+    "/github.com/mozilla/web-ext",
+    "/developers/addon/validate"
+  ],
+  "devhub_resources_promote_links": [
+    "/promote-your-add-ons-with-the-get-the-add-on-button/",
+    "extensionworkshop.com/documentation/publish/recommended-extensions/"
+  ],
+  "devhub_resources_review_addons_text": "Help make add-ons better by contributing your coding skills.",
+  "devhub_resources_participate_text": "You don't need coding skills to help keep Firefox the most customizable browser available!",
 
   "unlisted_submission_confirmation": "You’re done! ✨ You will be notified by email when the signed file is ready to be downloaded from the Developer Hub. If you do not see an email after 24 hours, please check your spam folder.",
   "listed_submission_confirmation": "You’re done! ✨ You will receive a confirmation email when this version is published on addons.mozilla.org. Note that it may take up to 24 hours before publication occurs, or longer if your add-on is selected for manual review. If you do not see an email after 24 hours, please check your spam folder.",

--- a/stage.json
+++ b/stage.json
@@ -139,7 +139,6 @@
     "extensionworkshop.allizom.org/documentation/publish/recommended-extensions/"
   ],
   "devhub_resources_review_addons_text": "Help make add-ons better by contributing your coding skills.",
-  "devhub_resources_write_some_code_text": "You don't need coding skills to help keep Firefox the most customisable browser available!",
   "devhub_resources_participate_text": "You don't need coding skills to help keep Firefox the most customizable browser available!",
   "devhub_submit_addon_agreement_header": "Add-on Distribution Agreement",
   "devhub_submit_addon_distribution_header": "How to Distribute this Version",

--- a/tests/devhub/test_devhub_home.py
+++ b/tests/devhub/test_devhub_home.py
@@ -324,17 +324,13 @@ def test_devhub_click_first_theme_button(selenium, base_url, variables):
 
 
 @pytest.mark.nondestructive
+@pytest.mark.sanity
+@pytest.mark.login("regular_user")
 def test_devhub_resources_footer_documentation_links_tc_id_C15072(selenium, base_url, variables):
     """Verifies that all "Documentation" links in the resources
     footer lead to the correct pages, confirming that
     the user is directed to the expected documentation sections."""
-    if "addons-dev" in base_url or "addons.allizom" in base_url:
-        pytest.skip(
-            "DevHub-Footer-sections Resources area was removed from the devhub home "
-            "page on both dev and stage"
-        )
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-    page.devhub_login("regular_user")
     assert "Documentation" in page.resources.documentation_section_header
     count = 0
     # looping through the actual number of Documentation links present in the resources footer
@@ -349,16 +345,12 @@ def test_devhub_resources_footer_documentation_links_tc_id_C15072(selenium, base
 
 
 @pytest.mark.nondestructive
-@pytest.mark.create_session("developer")
+@pytest.mark.sanity
+@pytest.mark.login("developer")
 def test_devhub_resources_footer_tools_links_tc_id_C15072(selenium, base_url, variables):
     """Ensures that all "Tools" links in the resources
     footer lead to the correct pages, verifying that
     the user is taken to the correct tool-related sections."""
-    if "addons-dev" in base_url or "addons.allizom" in base_url:
-        pytest.skip(
-            "DevHub-Footer-sections Resources area was removed from the devhub home "
-            "page on both dev and stage"
-        )
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     assert "Tools" in page.resources.tools_section_header
     count = 0
@@ -374,16 +366,12 @@ def test_devhub_resources_footer_tools_links_tc_id_C15072(selenium, base_url, va
 
 
 @pytest.mark.nondestructive
-@pytest.mark.create_session("developer")
+@pytest.mark.sanity
+@pytest.mark.login("developer")
 def test_devhub_resources_footer_promote_links_tc_id_C15072(selenium, base_url, variables):
     """Verifies that the "Promote" links in the resources footer
     lead to the correct pages, confirming that users are directed
     to the appropriate promotion-related sections."""
-    if "addons-dev" in base_url or "addons.allizom" in base_url:
-        pytest.skip(
-            "DevHub-Footer-sections Resources area was removed from the devhub home "
-            "page on both dev and stage"
-        )
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     assert "Promote" in page.resources.promote_section_header
     count = 0
@@ -399,16 +387,11 @@ def test_devhub_resources_footer_promote_links_tc_id_C15072(selenium, base_url, 
 
 
 @pytest.mark.nondestructive
-@pytest.mark.create_session("developer")
-def test_devhub_resources_join_addon_review(selenium, base_url, variables):
-    """Verifies that the "Join Add-on Review" link in the resources section
-    leads to the "Contribute/Code" section, allowing users
-    to participate in reviewing add-ons."""
-    if "addons-dev" in base_url or "addons.allizom" in base_url:
-        pytest.skip(
-            "DevHub-Footer-sections Resources area was removed from the devhub home "
-            "page on both dev and stage"
-        )
+@pytest.mark.sanity
+@pytest.mark.login("developer")
+def test_devhub_resources_write_some_code(selenium, base_url, variables):
+    """Verifies that the "Get started" link in the Resources footer's
+    "Write Some Code" card leads to wiki.mozilla.org/Add-ons/Contribute/Code."""
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
     assert "Write Some Code" in page.resources.review_addons_section_header
     assert (
@@ -419,31 +402,14 @@ def test_devhub_resources_join_addon_review(selenium, base_url, variables):
     page.wait_for_current_url("/Add-ons/Contribute/Code")
 
 
-# @pytest.mark.nondestructive
-# @pytest.mark.create_session("developer")
-# def test_devhub_resources_write_some_code(selenium, base_url, variables):
-#     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-#     assert "More Ways to Participate" in page.resources.write_code_section_header
-#     assert (
-#         variables["devhub_resources_write_some_code_text"]
-#         in page.resources.write_code_section_info_text
-#     )
-#     page.resources.click_write_code_section_link()
-#     page.wait_for_current_url("/Add-ons/Contribute/Code")
-
-
 @pytest.mark.nondestructive
+@pytest.mark.sanity
+@pytest.mark.login("regular_user")
 def test_devhub_resources_participate(selenium, base_url, variables):
     """Ensures that the "More Ways to Participate" link
     in the resources section redirects the user to the
     "Add-ons/Contribute" section."""
-    if "addons-dev" in base_url or "addons.allizom" in base_url:
-        pytest.skip(
-            "DevHub-Footer-sections Resources area was removed from the devhub home "
-            "page on both dev and stage"
-        )
     page = DevHubHome(selenium, base_url).open().wait_for_page_to_load()
-    page.devhub_login("regular_user")
     assert "More Ways to Participate" in page.resources.participate_section_header
     assert (
         variables["devhub_resources_participate_text"]


### PR DESCRIPTION
Follow-up to #1176. The 5 Resources footer tests in tests/devhub/test_devhub_home.py
were effectively dead everywhere: skipped by runtime check on dev + stage
("area was removed"), never selected by prod sanity (no @pytest.mark.sanity),
and prod full-suite runs would KeyError on missing prod.json keys.

Root cause of the dead state: the tests hit "logged-in only" DevHub content
and used mixed auth patterns that no longer worked under parallel CI. Tests
1 and 5 called page.devhub_login("regular_user") inline which hit FxA's
email-verification wall in Selenium. Tests 2, 3, and 4 used
@pytest.mark.create_session("developer") which reads the shared
developer.txt session — under parallel -n 4 workers, that session can be
stale before the suite's first login-marked test refreshes it, producing
"element not found" failures on the logged-out DevHub home page. Same
class of stale-session failure Schek fixed for 3 unrelated devhub tests
in #1184.

Tests (tests/devhub/test_devhub_home.py):
- Switch all 5 Resources tests to @pytest.mark.login("<user>") matching
  Schek's #1184 pattern. Login-marker path does a fresh FxA login and
  refreshes <user>.txt at the end, avoiding the stale-session race.
  User assignments preserved from the pre-existing tests:
    * documentation, participate → login("regular_user")
    * tools, promote, review → login("developer")
- Drop the runtime "if addons-dev or addons.allizom" skip block (5x).
- Drop the inline page.devhub_login("regular_user") in documentation and
  participate — the marker handles login now.
- Rename test_devhub_resources_join_addon_review ->
  test_devhub_resources_write_some_code. Historical name referred to a
  "Join Add-on Review" card that was merged into "Write Some Code"; the
  test body has been asserting on the "Write Some Code" card for a while
  but the function name never caught up. Docstring updated to match.
- Delete the commented-out test_devhub_resources_write_some_code block
  that pre-dated the rename (had inconsistent assertions targeting a
  different section's text — clearly abandoned work).
- Add @pytest.mark.sanity to all 5 Resources tests. They now pass on
  prod, so they belong in prod sanity coverage (same rationale as #1176).

Page object (pages/desktop/developers/devhub_home.py):
- Delete _write_code_section_header_locator, _write_code_info_text_locator,
  _write_code_link_locator + the 3 methods that used them
  (write_code_section_header, write_code_section_info_text,
  click_write_code_section_link). All were orphaned by the deleted
  commented block and their CSS selectors were byte-identical to the
  participate_* locators — dead code.

Config:
- prod.json: add 5 keys — devhub_resources_doc_links, devhub_resources_tools_links,
  devhub_resources_promote_links, devhub_resources_review_addons_text,
  devhub_resources_participate_text. Values verified by inspecting the
  live prod devhub footer. Notable adjustment from dev/stage values:
  extensionworkshop.allizom.org -> extensionworkshop.com on prod (the
  correct prod TLD, not extensionworkshop.mozilla.org which was our
  initial wrong guess).
- dev.json: fix stale devhub_resources_review_addons_text — old value
  "Volunteer reviewers help keep add-ons safe..." was for a deprecated
  card. Actual UI text on all 3 envs is
  "Help make add-ons better by contributing your coding skills."
- dev.json + stage.json: delete orphaned devhub_resources_write_some_code_text
  key. Only consumer was the deleted commented-out test block.

Verified locally headless (MOZ_HEADLESS=1, --driver Firefox):
- dev: all 5 green (documentation initially via foreground because
  regular_user hit an FxA email-code prompt on first login; subsequent
  runs clean headless)
- stage: all 5 green
- prod: all 5 green

Closes #1180
