### PR TITLE
Add devhub test for the Markdown-supported helper link dev/stage

### DIFF
--- a/pages/desktop/developers/edit_addon.py
+++ b/pages/desktop/developers/edit_addon.py
@@ -29,6 +29,11 @@ class EditAddon(Base):
     _edit_addon_media_button_locator = (By.CSS_SELECTOR, "#edit-addon-media a")
     _edit_addon_media_section_locator = (By.CSS_SELECTOR, "#edit-addon-media")
     _edit_addon_describe_section_locator = (By.CSS_SELECTOR, "#addon-edit-describe")
+    _edit_addon_describe_button_locator = (By.CSS_SELECTOR, "#addon-edit-describe a")
+    _markdown_support_link_locator = (
+        By.CSS_SELECTOR,
+        ".syntax-support a[href*='#make-use-of-markdown']",
+    )
     _add_screenshot_button_locator = (By.CSS_SELECTOR, "#screenshot-upload")
     _edit_previews_error_strong_locator = (By.CSS_SELECTOR, ".error > strong")
     _edit_previews_explicit_error_locator = (By.CSS_SELECTOR, ".error > ul >li")
@@ -82,6 +87,18 @@ class EditAddon(Base):
     @property
     def edit_addon_describe_section(self):
         return self.find_element(*self._edit_addon_describe_section_locator)
+
+    @property
+    def edit_addon_describe_button(self):
+        self.wait_for_element_to_be_clickable(self._edit_addon_describe_button_locator)
+        return self.find_element(*self._edit_addon_describe_button_locator)
+
+    @property
+    def markdown_support_link(self):
+        self.wait.until(
+            EC.visibility_of_element_located(self._markdown_support_link_locator)
+        )
+        return self.find_element(*self._markdown_support_link_locator)
 
     @property
     def screenshot_upload(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,7 +292,7 @@ def session_auth(request):
 
 
 @pytest.fixture
-def wait():
+def wait(selenium):
     """A preset wait to be used in test methods. Removes the necessity to declare a
     WebDriverWait whenever we need to wait for certain conditions to happen in a test"""
     return WebDriverWait(

--- a/tests/devhub/test_addon_edit.py
+++ b/tests/devhub/test_addon_edit.py
@@ -1,8 +1,36 @@
 import time
 import pytest
 
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+
 from pages.desktop.developers.devhub_home import DevHubHome
+from pages.desktop.developers.edit_addon import EditAddon
 from pages.desktop.developers.manage_versions import ManageVersions
+
+
+@pytest.mark.login("developer")
+def test_addon_edit_markdown_support_link(selenium, base_url, wait):
+    """Verify the Markdown-supported helper link in the Describe Add-on section
+    opens the correct Extension Workshop docs page."""
+    selenium.get(f"{base_url}/developers/addon/disable_version_auto/edit")
+    edit_addon = EditAddon(selenium, base_url).wait_for_page_to_load()
+    # expand the Describe Add-on section to reveal the syntax-support link
+    edit_addon.edit_addon_describe_button.click()
+    # wait for the AJAX expansion to complete (description textarea only
+    # appears in the expanded/edit state)
+    wait.until(EC.visibility_of_element_located((By.ID, "id_description_0")))
+    # click opens the docs page in a new tab
+    edit_addon.markdown_support_link.click()
+    wait.until(EC.number_of_windows_to_be(2))
+    selenium.switch_to.window(selenium.window_handles[1])
+    wait.until(EC.url_contains("create-an-appealing-listing"))
+    wait.until(EC.url_contains("make-use-of-markdown"))
+    wait.until(
+        EC.visibility_of_element_located(
+            (By.CSS_SELECTOR, "abbr[title^='The description, developer comments']")
+        )
+    )
 
 
 @pytest.mark.login("developer")


### PR DESCRIPTION
Adds a small check that the "Some Markdown supported." helper link in the devhub addon edit page's Describe Add-on section points to the correct Extension Workshop docs section.

Flow:
- Login as the `developer` user (via @pytest.mark.login).
- Navigate to `/developers/addon/disable_version_auto/edit` (the addon owned by the shared developer user in CI; used by the existing test_disable_enable_version_tc_id_c159074 in the same file).
- Click the Edit button on the Describe Add-on section to expand it (the syntax-support paragraph is not visible in the collapsed view).
- Click the "Some Markdown supported." link — opens in a new tab because `target="_blank"`.
- Switch to the new tab, wait for the URL to contain `create-an-appealing-listing` and `make-use-of-markdown`, then wait for the section abbr element `abbr[title^="The description, developer comments"]` to confirm the correct docs section rendered.

Placement: at the top of tests/devhub/test_addon_edit.py, above the two existing tests. Marker: @pytest.mark.login("developer") only — no sanity marker, so this test runs on devhub_parallel_tests (stage) and devhub_dev_parallel_tests (dev) via `-m "not serial and not prod_only"`, and is naturally excluded from scheduled_prod_sanity_run (which filters `-m "sanity"`). Prod coverage will be added in a follow-up once a prod addon is owned by the shared developer user (currently blocked by team availability).

Page object (pages/desktop/developers/edit_addon.py):
- New _edit_addon_describe_button_locator (`#addon-edit-describe a`) — mirrors the existing `_edit_addon_media_button_locator` pattern for the Media section's Edit button.
- New edit_addon_describe_button property with visibility+clickable wait.
- New _markdown_support_link_locator (`.syntax-support a[href*='#make-use-of-markdown']`) — scopes the match to the syntax-support paragraph so the anchor with the specific `#make-use-of-markdown` fragment is uniquely identified even if the helper paragraph appears near other form fields.
- New markdown_support_link property with visibility wait.

Bugfix in tests/conftest.py — the `wait` fixture:
The existing `wait` fixture did not declare `selenium` as a parameter, so it referenced the module-level `selenium` name — which is the fixture FUNCTION object, not the WebDriver instance. Passing that function to WebDriverWait as its "driver" worked silently for wait.until(...) calls that only touched WebElement.is_displayed() or similar, but broke for conditions like EC.number_of_windows_to_be(N) that read driver.window_handles. Adding `selenium` to the fixture parameter list lets pytest inject the actual driver, and the fixture now works consistently for all EC.* conditions.

Verified locally headless (Firefox) on dev and stage against the user's own developer-account addons (a-webextension-auto on dev, enable_disable_version_auto on stage) before the final swap back to the CI slug (`disable_version_auto`).

Closes #1162