### PR TITLE
fix url assertion

### DIFF
--- a/tests/frontend/test_addon_detail.py
+++ b/tests/frontend/test_addon_detail.py
@@ -184,7 +184,7 @@ def test_higher_firefox_incompatibility(selenium, base_url, variables):
     )
     # clicks on the Download button and checks that the download Firefox page opens
     addon.get_firefox_button.click()
-    addon.wait_for_current_url("/firefox/download/thanks/")
+    addon.wait_for_current_url("firefox.com/en-US/thanks/")
 
 
 @pytest.mark.nondestructive


### PR DESCRIPTION
`test_higher_firefox_incompatibility` in tests/frontend/test_addon_detail.py was failing on both stage and dev CI because Firefox's post-download page moved from `www.mozilla.org/firefox/download/thanks/` to `www.firefox.com/en-US/thanks/`. The `wait_for_current_url("/firefox/download/thanks/")` assertion could never match the new URL, so the test timed out at the last step of the flow (after the Get-Firefox button click succeeded and the browser navigated to firefox.com).

Fix: update the URL fragment to `firefox.com/en-US/thanks/`, matching the current firefox.com structure. This is the only place in tests/ or pages/ that referenced the old fragment (verified with `grep -rn "firefox/download/thanks"`), so no other callers need updating.

Verified locally: passes on both dev.json (foreground) and stage.json (headless).

Closes #1194