### PR TITLE
Pin geckodriver to 0.37.0 on all 12 Windows CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,13 @@ jobs:
           name: Install requirements
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
+          # Pinned to 0.37.0 for Firefox Nightly 155.x+ compatibility. Selenium's
+          # selenium_manager explicitly warns that 0.37.1 causes driver init failures
+          # on Firefox 155, which cascade into a "ValueError: I/O operation on
+          # closed file" error inside pytest-selenium's retry loop. Bump this pin
+          # when moving to a newer Nightly if a newer geckodriver is required.
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y
@@ -219,7 +224,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox -y
@@ -255,7 +260,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox -y
@@ -291,7 +296,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox -y
@@ -327,7 +332,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y
@@ -365,7 +370,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y
@@ -401,7 +406,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y
@@ -437,7 +442,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y
@@ -473,7 +478,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y
@@ -509,7 +514,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y
@@ -545,7 +550,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y
@@ -581,7 +586,7 @@ jobs:
           command: py -3.14 -m pip install -r ./requirements.txt
       - run:
           name: Install geckodriver
-          command: choco install selenium-gecko-driver -y
+          command: choco install selenium-gecko-driver --version=0.37.0 -y --force
       - run:
           name: Install Firefox
           command: choco install firefox-nightly --pre --ignore-checksums -y


### PR DESCRIPTION
Firefox Nightly bumped to 155.0.0.0 around 2026-07-21, and every Windows job with an unpinned `choco install selenium-gecko-driver -y` step then began installing geckodriver 0.37.1. Selenium's `selenium_manager` warns explicitly that 0.37.1 is not compatible with Firefox 155.x (recommends 0.37.0), and the driver-init failures that follow cascade into a "ValueError: I/O operation on closed file" error inside pytest-selenium's tenacity Retrying loop. Every affected test errors at setup and gets retried; the retries reuse a closed driver.log file handle and error the same way. The Windows CI produces 0 passed, N errored + 2N reruns.

Symptoms observed:
- scheduled_dev_regression_tests (Windows): 31 errors + 62 reruns, all ValueError: I/O operation on closed file at pytest-selenium driver init.
- scheduled_stage_release_run (Windows subset): same pattern.
- scheduled_prod_sanity_run (Windows): same pattern.
- scheduled_reviewer_tools_run, scheduled_webext_release_stage_run: presumed same, symptomatic timing matches.
- Linux jobs: unaffected. Linux uses cimg/python:3.14-browsers with a pre-baked geckodriver from the CircleCI image, and its subprocess.Popen code path on POSIX is different from Windows msvcrt.get_osfhandle().

Fix: pin every Windows `Install geckodriver` step to `--version=0.37.0` with `--force` so that any pre-existing 0.37.1 in the executor image gets overwritten.

Verified on the test-pin-geckodriver-0.37.0 experiment branch: with the pin applied to user_dev_serial_tests only, the job went from "31 errors, 62 rerun" to "29 passed, 5 skipped" in ~14 minutes. Same pin applied consistently across all 12 Windows jobs in this commit.

Added a comment above the first pinned install (in `coverage_devhub_tests`) explaining why 0.37.0 is required and when to bump it. The remaining 11 install steps mirror the same command without repeating the comment.

Note: this pin is a workaround for a specific Firefox/geckodriver version combination. When Firefox Nightly moves on (e.g., 156 arrives and requires a newer geckodriver), the pin will need to bump too. Preferring an unpinned `latest` here isn't safe — that's exactly what got us into this situation.

Closes #1196